### PR TITLE
Improve GUI controls and logging

### DIFF
--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -11,7 +11,7 @@ def build_global_tab(app):
         tk.Label(app.tab_global, text=delay_key).grid(row=row, column=0, sticky="w")
         var = tk.DoubleVar(value=app.settings.get(delay_key, 0.25))
         setattr(app, f"{delay_key}_var", var)
-        tk.Entry(app.tab_global, textvariable=var).grid(row=row, column=1, sticky="w")
+        tk.Spinbox(app.tab_global, textvariable=var, from_=0.0, to=5.0, increment=0.05, width=6).grid(row=row, column=1, sticky="w")
         row += 1
 
     tk.Label(app.tab_global, text="Per-Module Debug:").grid(row=row, column=0, sticky="w")
@@ -37,5 +37,7 @@ def build_global_tab(app):
             import json
             json.dump(app.settings, f, indent=2)
         tk.messagebox.showinfo("Saved", "Global settings saved.")
+        if hasattr(app, "update_hotkeys"):
+            app.update_hotkeys()
 
     tk.Button(app.tab_global, text="Save Settings", command=save_all).grid(row=row, column=0, pady=10)

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -1,7 +1,10 @@
 import tkinter as tk
-import pyautogui
+from tkinter import scrolledtext
 import time
 from scanner import scan_slot
+
+# Prevent pytest from treating this UI module as a test
+__test__ = False
 from breeding_logic import should_keep_egg
 from progress_tracker import (
     load_progress, save_progress,
@@ -11,8 +14,19 @@ from progress_tracker import (
 
 def build_test_tab(app):
     tk.Label(app.tab_test, text="Main Scripts", font=("Segoe UI", 10, "bold")).pack(pady=(10, 2))
-    tk.Button(app.tab_test, text="Start Live Scanning (F8)", command=app.start_live_run).pack(pady=5)
+
+    app.btn_start = tk.Button(app.tab_test, text="Start Live Scanning (F8)", command=app.start_live_run)
+    app.btn_start.pack(pady=5)
+    app.btn_pause = tk.Button(app.tab_test, text="Pause Scanning", command=lambda: app.toggle_pause(True), state="disabled")
+    app.btn_pause.pack(pady=5)
+    app.btn_resume = tk.Button(app.tab_test, text="Resume Scanning", command=lambda: app.toggle_pause(False), state="disabled")
+    app.btn_resume.pack(pady=5)
+
     tk.Button(app.tab_test, text="Scan Egg", command=lambda: test_scan_egg(app)).pack(pady=5)
+
+    # scrolling log viewer
+    app.log_widget = scrolledtext.ScrolledText(app.tab_test, height=15, state="disabled")
+    app.log_widget.pack(fill="both", expand=True, padx=5, pady=5)
 
     tk.Label(app.tab_test, text="Testing Utilities", font=("Segoe UI", 10, "bold")).pack(pady=(20, 2))
     tk.Button(app.tab_test, text="Force KEEP (Real Logic)", command=app.keep_egg).pack(pady=5)
@@ -65,6 +79,7 @@ def test_scan_egg(app):
             print(f"    debug[{k}]: {v}")
 
     if decision == "keep":
+        import pyautogui
         pyautogui.doubleClick(app.settings["slot_x"], app.settings["slot_y"])
         print("✔ Egg auto-kept via double-click")
 
@@ -118,5 +133,6 @@ def multi_egg_test(app):
             for k, v in reasons["_debug"].items():
                 print(f"    debug[{k}]: {v}")
         if decision == "keep":
+            import pyautogui
             pyautogui.doubleClick(app.settings["slot_x"], app.settings["slot_y"])
             print("→ Egg auto-kept via double-click")

--- a/tabs/species_tab.py
+++ b/tabs/species_tab.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 import json
 from progress_tracker import normalize_species_name
+from utils.helpers import refresh_species_dropdown
 
 DEFAULT_MODES = ["mutations", "all_females", "stat_merge", "top_stat_females", "war"]
 ALL_STATS = ["health", "stamina", "weight", "melee", "oxygen", "food"]
@@ -60,6 +61,9 @@ def build_species_tab(app):
     tk.Button(app.tab_species, text="Save Species Config", command=lambda: save_species_config(app)).grid(
         row=row, column=0, pady=10
     )
+    tk.Button(app.tab_species, text="Delete Species", command=lambda: delete_species(app)).grid(
+        row=row, column=1, pady=10
+    )
 
     def on_species_select(event):
         new = app.selected_species.get()
@@ -108,3 +112,18 @@ def save_species_config(app):
     with open("rules.json", "w", encoding="utf-8") as f:
         json.dump(app.rules, f, indent=2)
     messagebox.showinfo("Saved", f"Settings for {s} updated.")
+
+def delete_species(app):
+    s = app.selected_species.get()
+    if not s:
+        messagebox.showwarning("No species", "Select a species first.")
+        return
+    if not messagebox.askyesno("Confirm", f"Delete configuration for {s}?"):
+        return
+    if s in app.rules:
+        del app.rules[s]
+        with open("rules.json", "w", encoding="utf-8") as f:
+            json.dump(app.rules, f, indent=2)
+    app.selected_species.set("")
+    app._last_species = None
+    refresh_species_dropdown(app)


### PR DESCRIPTION
## Summary
- add pause/resume buttons and scrolling log viewer
- support deleting a species from config
- make delay fields spinboxes and refresh hotkeys when settings change
- add helper methods for GUI logging and hotkey refresh
- rename test tab to avoid pytest collection

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843907162b4832196ffa882df20351c