### PR TITLE
Refactor prints to logging, fix path usage

### DIFF
--- a/dump_structure.py
+++ b/dump_structure.py
@@ -1,4 +1,8 @@
 import os
+from pathlib import Path
+from logger import get_logger
+
+log = get_logger("dump_structure")
 
 def dump_tree(root, indent="", out_file=None):
     entries = sorted(os.listdir(root))
@@ -11,9 +15,12 @@ def dump_tree(root, indent="", out_file=None):
             extension = "    " if i == len(entries)-1 else "│   "
             dump_tree(path, indent + extension, out_file)
 
+BASE_DIR = Path(__file__).resolve().parent
+
 if __name__ == "__main__":
-    with open("project_tree.txt", "w") as f:
+    outfile = BASE_DIR / "project_tree.txt"
+    with outfile.open("w", encoding="utf-8") as f:
         print(os.getcwd(), file=f)
         dump_tree(os.getcwd(), out_file=f)
-    print("Wrote project_tree.txt")
+    log.info("Wrote project_tree.txt")
 

--- a/logger.py
+++ b/logger.py
@@ -1,10 +1,14 @@
 import logging
 import json
+from pathlib import Path
 
-# load your settings once
-with open("settings.json", encoding="utf-8") as f:
+# load your settings once using a path relative to this file
+BASE_DIR = Path(__file__).resolve().parent
+settings_file = BASE_DIR / "settings.json"
+with settings_file.open(encoding="utf-8") as f:
     cfg = json.load(f)
 debug_flags = cfg.get("debug_mode", {})
+
 
 def get_logger(module_name: str) -> logging.Logger:
     # if debug_flags is a dict, look up per-module;
@@ -20,7 +24,8 @@ def get_logger(module_name: str) -> logging.Logger:
     # avoid adding multiple handlers if called repeatedly
     if not logger.handlers:
         handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+        fmt = "%(asctime)s [%(levelname)s] %(message)s"
+        handler.setFormatter(logging.Formatter(fmt))
         logger.addHandler(handler)
     logger.setLevel(level)
     return logger

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -5,9 +5,11 @@ import json
 import os
 import re
 from difflib import get_close_matches
+from pathlib import Path
 
-PROGRESS_FILE = "breeding_progress.json"
-RULES_FILE    = "rules.json"
+BASE_DIR = Path(__file__).resolve().parent
+PROGRESS_FILE = BASE_DIR / "breeding_progress.json"
+RULES_FILE    = BASE_DIR / "rules.json"
 
 def load_progress():
     if os.path.exists(PROGRESS_FILE):

--- a/setup_positions.py
+++ b/setup_positions.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 import os, json, time
 import cv2, numpy as np, pyautogui, keyboard
+from pathlib import Path
+from logger import get_logger
 
-SETTINGS_FILE = "settings.json"
+log = get_logger("setup_positions")
+
+BASE_DIR = Path(__file__).resolve().parent
+SETTINGS_FILE = BASE_DIR / "settings.json"
 
 def wait_and_record(prompt):
-    print(prompt)
+    log.info(prompt)
     keyboard.wait("f9")
     x, y = pyautogui.position()
-    print(f"  → recorded: ({x}, {y})\n")
+    log.info("  → recorded: (%d, %d)\n", x, y)
     time.sleep(0.2)
     return x, y
 
@@ -23,11 +28,11 @@ def draw_roi(prompt, img):
     roi = cv2.selectROI(prompt, img, showCrosshair=False, fromCenter=False)
     cv2.destroyWindow(prompt)
     x, y, w, h = map(int, roi)
-    print(f"  → ROI = {{'x':{x}, 'y':{y}, 'w':{w}, 'h':{h}}}\n")
+    log.info("  → ROI = {'x':%d, 'y':%d, 'w':%d, 'h':%d}\n", x, y, w, h)
     return {"x": x, "y": y, "w": w, "h": h}
 
 def main():
-    print("=== Ark Single-Slot Scanner Calibration ===\n")
+    log.info("=== Ark Single-Slot Scanner Calibration ===\n")
 
     # 1) Egg slot
     slot_x, slot_y = wait_and_record("1) Hover over an EGG SLOT and press F9")
@@ -46,7 +51,7 @@ def main():
     destroy_this_offsets = [this_x - slot_x, this_y - slot_y]
 
     # 4) Open stats popup
-    print("4) Opening stats popup…")
+    log.info("4) Opening stats popup…")
     pyautogui.click(slot_x, slot_y)
     time.sleep(0.5)
 
@@ -113,7 +118,7 @@ def main():
     with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
         json.dump(cfg, f, indent=2)
 
-    print(f"\n✅ Calibration complete — saved to {SETTINGS_FILE}")
+    log.info("\n✅ Calibration complete — saved to %s", SETTINGS_FILE)
 
 if __name__ == "__main__":
     main()

--- a/stat_list.py
+++ b/stat_list.py
@@ -2,12 +2,17 @@
 import json
 import os
 import sys
+from pathlib import Path
+from logger import get_logger
 
-PROGRESS_FILE     = "breeding_progress.json"
-EXTRA_TAMES_FILE  = "extra_tames.json"
-RULES_FILE        = "rules.json"
-SETTINGS_FILE     = "settings.json"
-OUTPUT_FILE       = "stat_list.txt"
+log = get_logger("stat_list")
+
+BASE_DIR = Path(__file__).resolve().parent
+PROGRESS_FILE     = BASE_DIR / "breeding_progress.json"
+EXTRA_TAMES_FILE  = BASE_DIR / "extra_tames.json"
+RULES_FILE        = BASE_DIR / "rules.json"
+SETTINGS_FILE     = BASE_DIR / "settings.json"
+OUTPUT_FILE       = BASE_DIR / "stat_list.txt"
 
 def load_json(path):
     if not os.path.exists(path):
@@ -23,9 +28,9 @@ def get_mode(settings):
     m = settings.get("stat_list_mode")
     if m in ("full", "mutation"):
         return m
-    print("Choose display mode:")
-    print("  1) full      — show every stud & mutation stat")
-    print("  2) mutation  — only stats in each species' mutation_stats")
+    log.info("Choose display mode:")
+    log.info("  1) full      — show every stud & mutation stat")
+    log.info("  2) mutation  — only stats in each species' mutation_stats")
     choice = input("Enter 1 or 2: ").strip()
     mode = "mutation" if choice == "2" else "full"
     settings["stat_list_mode"] = mode
@@ -98,7 +103,7 @@ def main():
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + ("\n" if lines else ""))
 
-    print(f"Wrote {len(lines)} lines to '{OUTPUT_FILE}' in {mode!r} mode.")
+    log.info("Wrote %d lines to '%s' in %r mode.", len(lines), OUTPUT_FILE, mode)
 
 if __name__ == "__main__":
     main()

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -1,4 +1,7 @@
 import tkinter as tk
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 def build_global_tab(app):
     row = 0
@@ -33,7 +36,7 @@ def build_global_tab(app):
         app.settings["action_delay"] = app.action_delay_var.get()
         app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
         app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
-        with open("settings.json", "w", encoding="utf-8") as f:
+        with open(str(BASE_DIR/"settings.json"), "w", encoding="utf-8") as f:
             import json
             json.dump(app.settings, f, indent=2)
         tk.messagebox.showinfo("Saved", "Global settings saved.")

--- a/tabs/species_tab.py
+++ b/tabs/species_tab.py
@@ -1,6 +1,9 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 import json
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
 from progress_tracker import normalize_species_name
 
 DEFAULT_MODES = ["mutations", "all_females", "stat_merge", "top_stat_females", "war"]
@@ -74,7 +77,7 @@ def build_species_tab(app):
                 "war_stats": [s for s, var in app.stat_vars.items() if var.get()]
             }
             app.rules[old] = rule
-            with open("rules.json", "w", encoding="utf-8") as f:
+            with open(str(BASE_DIR / "rules.json"), "w", encoding="utf-8") as f:
                 json.dump(app.rules, f, indent=2)
         # load new
         app._last_species = new
@@ -105,6 +108,6 @@ def save_species_config(app):
         "top_stat_females_stats": [s for s, var in app.stat_vars.items() if var.get()],
         "war_stats": [s for s, var in app.stat_vars.items() if var.get()]
     }
-    with open("rules.json", "w", encoding="utf-8") as f:
+    with open(str(BASE_DIR / "rules.json"), "w", encoding="utf-8") as f:
         json.dump(app.rules, f, indent=2)
     messagebox.showinfo("Saved", f"Settings for {s} updated.")

--- a/tabs/test_tab.py
+++ b/tabs/test_tab.py
@@ -1,6 +1,9 @@
 import tkinter as tk
 import pyautogui
 import time
+from logger import get_logger
+
+log = get_logger("test_tab")
 from scanner import scan_slot
 from breeding_logic import should_keep_egg
 from progress_tracker import (
@@ -23,12 +26,12 @@ def build_test_tab(app):
 
 def test_scan_egg(app):
     if getattr(app, "scanning_paused", False):
-        print("🔁 Scanning is paused. Press F9 to resume.")
+        log.info("🔁 Scanning is paused. Press F9 to resume.")
         return
 
     scan = scan_slot(app.settings)
     if scan == "no_egg":
-        print("→ No egg detected.")
+        log.info("→ No egg detected.")
         return
 
     egg = scan["species"]
@@ -56,35 +59,35 @@ def test_scan_egg(app):
     decision, reasons = should_keep_egg(scan, config, progress)
     save_progress(progress)
 
-    print(f"→ Scanned Egg: {egg} | DECISION: {decision.upper()}")
+    log.info(f"→ Scanned Egg: {egg} | DECISION: {decision.upper()}")
     for k, v in reasons.items():
         if k != "_debug" and v:
-            print(f"  ✔ {k}")
+            log.info(f"  ✔ {k}")
     if "_debug" in reasons:
         for k, v in reasons["_debug"].items():
-            print(f"    debug[{k}]: {v}")
+            log.info(f"    debug[{k}]: {v}")
 
     if decision == "keep":
         pyautogui.doubleClick(app.settings["slot_x"], app.settings["slot_y"])
-        print("✔ Egg auto-kept via double-click")
+        log.info("✔ Egg auto-kept via double-click")
 
 def multi_egg_test(app):
     try:
         count = int(input("How many eggs to scan for test? "))
     except:
-        print("Invalid number.")
+        log.info("Invalid number.")
         return
-    print(f"Scanning {count} eggs...")
+    log.info(f"Scanning {count} eggs...")
     progress = load_progress()
 
     for i in range(1, count + 1):
         if getattr(app, "scanning_paused", False):
-            print(f"🔁 Skipping scan {i}, scanning is paused.")
+            log.info(f"🔁 Skipping scan {i}, scanning is paused.")
             continue
 
         scan = scan_slot(app.settings)
         if scan == "no_egg":
-            print(f"Egg {i}: no egg found.")
+            log.info(f"Egg {i}: no egg found.")
             continue
 
         egg = scan["species"]
@@ -110,13 +113,13 @@ def multi_egg_test(app):
         decision, reasons = should_keep_egg(scan, config, progress)
         save_progress(progress)
 
-        print(f"Egg {i}: {egg} | DECISION: {decision.upper()}")
+        log.info(f"Egg {i}: {egg} | DECISION: {decision.upper()}")
         for k, v in reasons.items():
             if k != "_debug" and v:
-                print(f"  ✔ {k}")
+                log.info(f"  ✔ {k}")
         if "_debug" in reasons:
             for k, v in reasons["_debug"].items():
-                print(f"    debug[{k}]: {v}")
+                log.info(f"    debug[{k}]: {v}")
         if decision == "keep":
             pyautogui.doubleClick(app.settings["slot_x"], app.settings["slot_y"])
-            print("→ Egg auto-kept via double-click")
+            log.info("→ Egg auto-kept via double-click")

--- a/tabs/tools_tab.py
+++ b/tabs/tools_tab.py
@@ -2,7 +2,10 @@ import tkinter as tk
 from tkinter import messagebox
 import json
 import subprocess
+from pathlib import Path
 from utils.helpers import refresh_species_dropdown
+
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 ALL_STATS = ["health", "stamina", "weight", "melee", "oxygen", "food"]
 DEFAULT_MODES = ["mutations", "all_females", "stat_merge", "top_stat_females", "war"]
@@ -65,7 +68,7 @@ def refresh_species(app):
         if species not in app.rules:
             app.rules[species] = default.copy()
             new_added += 1
-    with open("rules.json", "w", encoding="utf-8") as f:
+    with open(str(BASE_DIR/"rules.json"), "w", encoding="utf-8") as f:
         json.dump(app.rules, f, indent=2)
     from utils.helpers import refresh_species_dropdown
     refresh_species_dropdown(app)
@@ -77,7 +80,7 @@ def save_all(app):
     app.settings["action_delay"] = app.action_delay_var.get()
     app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
     app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
-    with open("settings.json", "w", encoding="utf-8") as f:
+    with open(str(BASE_DIR/"settings.json"), "w", encoding="utf-8") as f:
         json.dump(app.settings, f, indent=2)
     messagebox.showinfo("Saved", "All settings saved.")
 
@@ -89,6 +92,6 @@ def set_defaults(app):
         "top_stat_females_stats": [stat for stat, var in app.default_stat_vars.items() if var.get()],
         "war_stats": [stat for stat, var in app.default_stat_vars.items() if var.get()]
     }
-    with open("settings.json", "w", encoding="utf-8") as f:
+    with open(str(BASE_DIR/"settings.json"), "w", encoding="utf-8") as f:
         json.dump(app.settings, f, indent=2)
     messagebox.showinfo("Defaults Saved", "Defaults for new species saved.")


### PR DESCRIPTION
## Summary
- apply path resolution fix to multiple modules
- replace print statements with logger calls
- ensure config files are loaded relative to module directory

## Testing
- `python -m py_compile *.py utils/*.py tabs/*.py`
- `flake8 logger.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438f5dfa548321bd572774d967644f