### PR TITLE
Enhance tab widgets with tooltips

### DIFF
--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -1,30 +1,58 @@
 import tkinter as tk
+from tkinter import ttk
+
+from utils.helpers import add_tooltip
+
+FONT = ("Segoe UI", 10)
 
 def build_global_tab(app):
     row = 0
-    tk.Label(app.tab_global, text="Hotkey Scan").grid(row=row, column=0, sticky="w")
+    ttk.Label(app.tab_global, text="Hotkey Scan", font=FONT).grid(
+        row=row, column=0, sticky="w", padx=5, pady=2
+    )
     app.hotkey_var = tk.StringVar(value=app.settings.get("hotkey_scan", "F8"))
-    tk.Entry(app.tab_global, textvariable=app.hotkey_var).grid(row=row, column=1, sticky="w")
+    entry = ttk.Entry(app.tab_global, textvariable=app.hotkey_var, width=10)
+    entry.grid(row=row, column=1, sticky="w", padx=5, pady=2)
+    add_tooltip(entry, "Keyboard hotkey to start live scanning")
     row += 1
 
     for delay_key in ["popup_delay", "action_delay", "scan_loop_delay"]:
-        tk.Label(app.tab_global, text=delay_key).grid(row=row, column=0, sticky="w")
+        label = delay_key.replace("_", " ").title()
+        ttk.Label(app.tab_global, text=label, font=FONT).grid(
+            row=row, column=0, sticky="w", padx=5, pady=2
+        )
         var = tk.DoubleVar(value=app.settings.get(delay_key, 0.25))
         setattr(app, f"{delay_key}_var", var)
-        tk.Spinbox(app.tab_global, textvariable=var, from_=0.0, to=5.0, increment=0.05, width=6).grid(row=row, column=1, sticky="w")
+        spin = ttk.Spinbox(
+            app.tab_global,
+            textvariable=var,
+            from_=0.0,
+            to=5.0,
+            increment=0.05,
+            width=8,
+        )
+        spin.grid(row=row, column=1, sticky="w", padx=5, pady=2)
+        add_tooltip(spin, f"{label} in seconds")
         row += 1
 
-    tk.Label(app.tab_global, text="Per-Module Debug:").grid(row=row, column=0, sticky="w")
+    ttk.Label(app.tab_global, text="Per-Module Debug:", font=FONT).grid(
+        row=row, column=0, sticky="w", padx=5, pady=(10, 2)
+    )
     row += 1
 
     debug_config = app.settings.get("debug_mode", {})
     if isinstance(debug_config, bool):
-        debug_config = {k: debug_config for k in ["scanner", "scan_eggs", "progress_tracker", "breeding_logic"]}
+        debug_config = {
+            k: debug_config
+            for k in ["scanner", "scan_eggs", "progress_tracker", "breeding_logic"]
+        }
     app.debug_vars = {}
     for mod in ["scanner", "scan_eggs", "progress_tracker", "breeding_logic"]:
         var = tk.BooleanVar(value=debug_config.get(mod, False))
         app.debug_vars[mod] = var
-        tk.Checkbutton(app.tab_global, text=mod, variable=var).grid(row=row, column=1, sticky="w")
+        cb = ttk.Checkbutton(app.tab_global, text=mod, variable=var)
+        cb.grid(row=row, column=1, sticky="w", padx=5, pady=1)
+        add_tooltip(cb, f"Enable debug logs for {mod}")
         row += 1
 
     def save_all():
@@ -40,4 +68,6 @@ def build_global_tab(app):
         if hasattr(app, "update_hotkeys"):
             app.update_hotkeys()
 
-    tk.Button(app.tab_global, text="Save Settings", command=save_all).grid(row=row, column=0, pady=10)
+    ttk.Button(app.tab_global, text="Save Settings", command=save_all).grid(
+        row=row, column=0, columnspan=2, pady=10
+    )

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -1,7 +1,10 @@
 import tkinter as tk
-from tkinter import scrolledtext
+from tkinter import ttk, scrolledtext
 import time
 from scanner import scan_slot
+from utils.helpers import add_tooltip
+
+FONT = ("Segoe UI", 10)
 
 # Prevent pytest from treating this UI module as a test
 __test__ = False
@@ -13,25 +16,48 @@ from progress_tracker import (
 )
 
 def build_test_tab(app):
-    tk.Label(app.tab_test, text="Main Scripts", font=("Segoe UI", 10, "bold")).pack(pady=(10, 2))
+    ttk.Label(app.tab_test, text="Main Scripts", font=(FONT[0], FONT[1], "bold")).pack(pady=(10, 2))
 
-    app.btn_start = tk.Button(app.tab_test, text="Start Live Scanning (F8)", command=app.start_live_run)
+    app.btn_start = ttk.Button(app.tab_test, text="Start Live Scanning (F8)", command=app.start_live_run)
     app.btn_start.pack(pady=5)
-    app.btn_pause = tk.Button(app.tab_test, text="Pause Scanning", command=lambda: app.toggle_pause(True), state="disabled")
-    app.btn_pause.pack(pady=5)
-    app.btn_resume = tk.Button(app.tab_test, text="Resume Scanning", command=lambda: app.toggle_pause(False), state="disabled")
-    app.btn_resume.pack(pady=5)
+    add_tooltip(app.btn_start, "Begin automated scanning using hotkey settings")
 
-    tk.Button(app.tab_test, text="Scan Egg", command=lambda: test_scan_egg(app)).pack(pady=5)
+    app.btn_pause = ttk.Button(
+        app.tab_test,
+        text="Pause Scanning",
+        command=lambda: app.toggle_pause(True),
+        state="disabled",
+    )
+    app.btn_pause.pack(pady=5)
+    add_tooltip(app.btn_pause, "Temporarily halt the live scan loop")
+
+    app.btn_resume = ttk.Button(
+        app.tab_test,
+        text="Resume Scanning",
+        command=lambda: app.toggle_pause(False),
+        state="disabled",
+    )
+    app.btn_resume.pack(pady=5)
+    add_tooltip(app.btn_resume, "Resume scanning if paused")
+
+    btn = ttk.Button(app.tab_test, text="Scan Egg", command=lambda: test_scan_egg(app))
+    btn.pack(pady=5)
+    add_tooltip(btn, "Single manual scan of the configured slot")
 
     # scrolling log viewer
     app.log_widget = scrolledtext.ScrolledText(app.tab_test, height=15, state="disabled")
     app.log_widget.pack(fill="both", expand=True, padx=5, pady=5)
 
-    tk.Label(app.tab_test, text="Testing Utilities", font=("Segoe UI", 10, "bold")).pack(pady=(20, 2))
-    tk.Button(app.tab_test, text="Force KEEP (Real Logic)", command=app.keep_egg).pack(pady=5)
-    tk.Button(app.tab_test, text="Force DESTROY (Real Logic)", command=app.destroy_egg).pack(pady=5)
-    tk.Button(app.tab_test, text="Multi-Egg Scan Test", command=lambda: multi_egg_test(app)).pack(pady=10)
+    ttk.Label(app.tab_test, text="Testing Utilities", font=(FONT[0], FONT[1], "bold")).pack(pady=(20, 2))
+    btn = ttk.Button(app.tab_test, text="Force KEEP (Real Logic)", command=app.keep_egg)
+    btn.pack(pady=5)
+    add_tooltip(btn, "Invoke keep logic directly")
+    btn = ttk.Button(app.tab_test, text="Force DESTROY (Real Logic)", command=app.destroy_egg)
+    btn.pack(pady=5)
+    add_tooltip(btn, "Invoke destroy logic directly")
+    btn = ttk.Button(app.tab_test, text="Multi-Egg Scan Test", command=lambda: multi_egg_test(app))
+    btn.pack(pady=10)
+    add_tooltip(btn, "Run multiple scans for debugging")
 
 
 

--- a/tabs/species_tab.py
+++ b/tabs/species_tab.py
@@ -1,15 +1,19 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
+
+from utils.helpers import refresh_species_dropdown, add_tooltip
+
+FONT = ("Segoe UI", 10)
 import json
 from progress_tracker import normalize_species_name
-from utils.helpers import refresh_species_dropdown
-
 DEFAULT_MODES = ["mutations", "all_females", "stat_merge", "top_stat_females", "war"]
 ALL_STATS = ["health", "stamina", "weight", "melee", "oxygen", "food"]
 
 def build_species_tab(app):
     row = 0
-    tk.Label(app.tab_species, text="Select Species:").grid(row=row, column=0, sticky="w")
+    ttk.Label(app.tab_species, text="Select Species:", font=FONT).grid(
+        row=row, column=0, sticky="w", padx=5, pady=2
+    )
     app.selected_species = tk.StringVar()
     # Track last-loaded species for autosave
     app._last_species = None
@@ -19,9 +23,11 @@ def build_species_tab(app):
         app.tab_species,
         values=app.species_list,
         textvariable=app.selected_species,
-        state="readonly"
+        state="readonly",
+        width=30,
     )
-    app.species_dropdown.grid(row=row, column=1, sticky="w")
+    app.species_dropdown.grid(row=row, column=1, sticky="w", padx=5, pady=2)
+    add_tooltip(app.species_dropdown, "Species configuration to edit")
     row += 1
 
     # Checkbox vars
@@ -30,38 +36,44 @@ def build_species_tab(app):
     app.mutation_stat_vars = {stat: tk.BooleanVar() for stat in ALL_STATS}
 
     # Placeholders for load/save buttons (now optional)
-    tk.Label(app.tab_species, text="Enabled Modes:").grid(row=row, column=0, sticky="nw")
+    ttk.Label(app.tab_species, text="Enabled Modes:", font=FONT).grid(
+        row=row, column=0, sticky="nw", padx=5, pady=2
+    )
     col = 1
     for mode in DEFAULT_MODES:
-        tk.Checkbutton(app.tab_species, text=mode, variable=app.mode_vars[mode]).grid(
-            row=row, column=col, sticky="w"
-        )
+        cb = ttk.Checkbutton(app.tab_species, text=mode, variable=app.mode_vars[mode])
+        cb.grid(row=row, column=col, sticky="w", padx=5, pady=2)
+        add_tooltip(cb, f"Enable {mode} mode")
         col += 1
     row += 1
 
-    tk.Label(app.tab_species, text="Shared Stats (merge/top/war):").grid(row=row, column=0, sticky="nw")
-    sf = tk.Frame(app.tab_species)
+    ttk.Label(app.tab_species, text="Shared Stats (merge/top/war):", font=FONT).grid(
+        row=row, column=0, sticky="nw", padx=5, pady=(10, 2)
+    )
+    sf = ttk.Frame(app.tab_species)
     sf.grid(row=row, column=1, columnspan=3, sticky="w")
     for i, stat in enumerate(ALL_STATS):
-        tk.Checkbutton(sf, text=stat, variable=app.stat_vars[stat]).grid(
-            row=i//3, column=i%3, sticky="w", padx=5, pady=1
-        )
+        cb = ttk.Checkbutton(sf, text=stat, variable=app.stat_vars[stat])
+        cb.grid(row=i//3, column=i%3, sticky="w", padx=5, pady=1)
+        add_tooltip(cb, f"Track {stat} for merges/top/war")
     row += 1
 
-    tk.Label(app.tab_species, text="Mutation Stats:").grid(row=row, column=0, sticky="nw")
-    mf = tk.Frame(app.tab_species)
+    ttk.Label(app.tab_species, text="Mutation Stats:", font=FONT).grid(
+        row=row, column=0, sticky="nw", padx=5, pady=(10, 2)
+    )
+    mf = ttk.Frame(app.tab_species)
     mf.grid(row=row, column=1, columnspan=3, sticky="w")
     for i, stat in enumerate(ALL_STATS):
-        tk.Checkbutton(mf, text=stat, variable=app.mutation_stat_vars[stat]).grid(
-            row=i//3, column=i%3, sticky="w", padx=5, pady=1
-        )
+        cb = ttk.Checkbutton(mf, text=stat, variable=app.mutation_stat_vars[stat])
+        cb.grid(row=i//3, column=i%3, sticky="w", padx=5, pady=1)
+        add_tooltip(cb, f"Watch mutations for {stat}")
     row += 1
 
     # Optional manual save button (can hide if you don't need it)
-    tk.Button(app.tab_species, text="Save Species Config", command=lambda: save_species_config(app)).grid(
+    ttk.Button(app.tab_species, text="Save Species Config", command=lambda: save_species_config(app)).grid(
         row=row, column=0, pady=10
     )
-    tk.Button(app.tab_species, text="Delete Species", command=lambda: delete_species(app)).grid(
+    ttk.Button(app.tab_species, text="Delete Species", command=lambda: delete_species(app)).grid(
         row=row, column=1, pady=10
     )
 

--- a/tabs/tools_tab.py
+++ b/tabs/tools_tab.py
@@ -1,54 +1,78 @@
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import ttk, messagebox
 import json
 import subprocess
-from utils.helpers import refresh_species_dropdown
+from utils.helpers import refresh_species_dropdown, add_tooltip
+
+FONT = ("Segoe UI", 10)
 
 ALL_STATS = ["health", "stamina", "weight", "melee", "oxygen", "food"]
 DEFAULT_MODES = ["mutations", "all_females", "stat_merge", "top_stat_females", "war"]
 
 def build_tools_tab(app):
     row = 0
-    tk.Button(app.tab_tools, text="Run Calibration", command=run_calibration).grid(row=row, column=0, sticky="w")
+    btn = ttk.Button(app.tab_tools, text="Run Calibration", command=run_calibration)
+    btn.grid(row=row, column=0, sticky="w", padx=5, pady=2)
+    add_tooltip(btn, "Run setup_positions.py to calibrate UI coordinates")
     row += 1
-    tk.Button(app.tab_tools, text="Refresh from Progress", command=lambda: refresh_species(app)).grid(row=row, column=0, sticky="w")
+
+    btn = ttk.Button(app.tab_tools, text="Refresh from Progress", command=lambda: refresh_species(app))
+    btn.grid(row=row, column=0, sticky="w", padx=5, pady=2)
+    add_tooltip(btn, "Create rules entries from progress.json")
     row += 1
-    tk.Button(app.tab_tools, text="Save All Settings", command=lambda: save_all(app)).grid(row=row, column=0, sticky="w")
+
+    btn = ttk.Button(app.tab_tools, text="Save All Settings", command=lambda: save_all(app))
+    btn.grid(row=row, column=0, sticky="w", padx=5, pady=2)
+    add_tooltip(btn, "Write all current settings to disk")
     row += 2
-    tk.Label(app.tab_tools, text="Default Settings for New Species:", font=("Segoe UI", 10, "bold")).grid(row=row, column=0, sticky="w")
+
+    ttk.Label(app.tab_tools, text="Default Settings for New Species:", font=("Segoe UI", 10, "bold")).grid(
+        row=row, column=0, sticky="w", padx=5, pady=2
+    )
     row += 1
 
     app.default_mode_vars = {mode: tk.BooleanVar(value=True) for mode in DEFAULT_MODES}
-    tk.Label(app.tab_tools, text="Enabled Modes:").grid(row=row, column=0, sticky="nw")
+    ttk.Label(app.tab_tools, text="Enabled Modes:", font=FONT).grid(
+        row=row, column=0, sticky="nw", padx=5, pady=2
+    )
     col = 1
     for mode in DEFAULT_MODES:
-        cb = tk.Checkbutton(app.tab_tools, text=mode, variable=app.default_mode_vars[mode])
-        cb.grid(row=row, column=col, sticky="w")
+        cb = ttk.Checkbutton(app.tab_tools, text=mode, variable=app.default_mode_vars[mode])
+        cb.grid(row=row, column=col, sticky="w", padx=5, pady=2)
+        add_tooltip(cb, f"Default enable {mode} mode")
         col += 1
     row += 1
 
     app.default_stat_vars = {stat: tk.BooleanVar(value=True) for stat in ALL_STATS}
     app.default_mutation_vars = {stat: tk.BooleanVar(value=True) for stat in ALL_STATS}
 
-    tk.Label(app.tab_tools, text="Shared Stats (merge/top/war):").grid(row=row, column=0, sticky="w", pady=(10, 2))
+    ttk.Label(app.tab_tools, text="Shared Stats (merge/top/war):", font=FONT).grid(
+        row=row, column=0, sticky="w", padx=5, pady=(10, 2)
+    )
     row += 1
-    sf = tk.Frame(app.tab_tools)
+    sf = ttk.Frame(app.tab_tools)
     sf.grid(row=row, column=0, columnspan=3, sticky="w")
     for i, stat in enumerate(ALL_STATS):
-        cb = tk.Checkbutton(sf, text=stat, variable=app.default_stat_vars[stat])
+        cb = ttk.Checkbutton(sf, text=stat, variable=app.default_stat_vars[stat])
         cb.grid(row=i//3, column=i%3, sticky="w", padx=10, pady=2)
+        add_tooltip(cb, f"Track {stat} by default")
     row += 1
 
-    tk.Label(app.tab_tools, text="Mutation Stats:").grid(row=row, column=0, sticky="w", pady=(10, 2))
+    ttk.Label(app.tab_tools, text="Mutation Stats:", font=FONT).grid(
+        row=row, column=0, sticky="w", padx=5, pady=(10, 2)
+    )
     row += 1
-    mf = tk.Frame(app.tab_tools)
+    mf = ttk.Frame(app.tab_tools)
     mf.grid(row=row, column=0, columnspan=3, sticky="w")
     for i, stat in enumerate(ALL_STATS):
-        cb = tk.Checkbutton(mf, text=stat, variable=app.default_mutation_vars[stat])
+        cb = ttk.Checkbutton(mf, text=stat, variable=app.default_mutation_vars[stat])
         cb.grid(row=i//3, column=i%3, sticky="w", padx=10, pady=2)
+        add_tooltip(cb, f"Default mutation stat {stat}")
     row += 1
 
-    tk.Button(app.tab_tools, text="Apply These Defaults to New Species", command=lambda: set_defaults(app)).grid(row=row, column=0, pady=10)
+    btn = ttk.Button(app.tab_tools, text="Apply These Defaults to New Species", command=lambda: set_defaults(app))
+    btn.grid(row=row, column=0, pady=10)
+    add_tooltip(btn, "Save defaults for new species to settings.json")
 
 def run_calibration():
     try:

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,3 +1,30 @@
+import tkinter as tk
+from tkinter import ttk
+
+
 def refresh_species_dropdown(app):
     if hasattr(app, "species_dropdown"):
         app.species_dropdown["values"] = list(app.rules.keys())
+
+
+def add_tooltip(widget, text: str) -> None:
+    """Attach a simple tooltip to ``widget`` displaying ``text``."""
+
+    tip = tk.Toplevel(widget)
+    tip.wm_overrideredirect(True)
+    tip.withdraw()
+    lbl = ttk.Label(tip, text=text, background="#ffffe0", relief="solid", borderwidth=1)
+    lbl.pack(ipadx=2, ipady=1)
+
+    def show(_):
+        x = widget.winfo_rootx() + 20
+        y = widget.winfo_rooty() + widget.winfo_height() + 5
+        tip.wm_geometry(f"+{x}+{y}")
+        tip.deiconify()
+
+    def hide(_):
+        tip.withdraw()
+
+    widget.bind("<Enter>", show)
+    widget.bind("<Leave>", hide)
+


### PR DESCRIPTION
## Summary
- tweak tab layout spacing
- convert widgets to ttk and add a tooltip helper
- attach tooltips to controls in all tabs

## Testing
- `python -m py_compile tabs/global_tab.py tabs/species_tab.py tabs/tools_tab.py tabs/script_control_tab.py utils/helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_6843b09524b8832189788a671b6984ee