### PR TITLE
Add verify_rules CLI tool

### DIFF
--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import scrolledtext
 import time
+import subprocess
 from scanner import scan_slot
 
 # Prevent pytest from treating this UI module as a test
@@ -32,6 +33,7 @@ def build_test_tab(app):
     tk.Button(app.tab_test, text="Force KEEP (Real Logic)", command=app.keep_egg).pack(pady=5)
     tk.Button(app.tab_test, text="Force DESTROY (Real Logic)", command=app.destroy_egg).pack(pady=5)
     tk.Button(app.tab_test, text="Multi-Egg Scan Test", command=lambda: multi_egg_test(app)).pack(pady=10)
+    tk.Button(app.tab_test, text="Verify Rules (CLI)", command=verify_rules_cli).pack(pady=5)
 
 
 
@@ -136,3 +138,10 @@ def multi_egg_test(app):
             import pyautogui
             pyautogui.doubleClick(app.settings["slot_x"], app.settings["slot_y"])
             print("→ Egg auto-kept via double-click")
+
+def verify_rules_cli():
+    try:
+        subprocess.run(["python", "verify_rules.py"], check=False)
+    except Exception as e:
+        print(f"Error running verify_rules.py: {e}")
+

--- a/verify_rules.py
+++ b/verify_rules.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Check which breeding modes would keep a given egg.
+
+Usage:
+  python verify_rules.py "Species Name" male --stat health=35+2 --stat stamina=30
+
+Run without --stat options to be prompted interactively for each stat.
+"""
+import argparse
+import json
+import os
+
+from breeding_logic import should_keep_egg
+from progress_tracker import load_progress, normalize_species_name
+
+ALL_STATS = ["health", "stamina", "weight", "melee", "oxygen", "food"]
+
+RULES_FILE = "rules.json"
+SETTINGS_FILE = "settings.json"
+
+def load_rules():
+    if os.path.exists(RULES_FILE):
+        with open(RULES_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+def load_settings():
+    if os.path.exists(SETTINGS_FILE):
+        with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+def parse_stat(text: str):
+    name, val = text.split("=", 1)
+    name = name.lower()
+    base, mut = 0, 0
+    if "+" in val:
+        base, mut = val.split("+", 1)
+    elif "/" in val:
+        base, mut = val.split("/", 1)
+    else:
+        base = val
+    return name, {"base": int(base), "mutation": int(mut)}
+
+def collect_stats(args):
+    stats = {s: {"base": 0, "mutation": 0} for s in ALL_STATS}
+    if args.stat:
+        for s in args.stat:
+            k, v = parse_stat(s)
+            if k in stats:
+                stats[k] = v
+    else:
+        print("Enter base or base+mut for each stat (blank to skip):")
+        for st in ALL_STATS:
+            inp = input(f"  {st}: ").strip()
+            if inp:
+                k, v = parse_stat(f"{st}={inp}")
+                stats[k] = v
+    return stats
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify breeding rules")
+    parser.add_argument("species", help="Species name as shown in game")
+    parser.add_argument("sex", choices=["male", "female"], help="Egg sex")
+    parser.add_argument(
+        "--stat",
+        action="append",
+        metavar="STAT=BASE+MUT",
+        help="Provide stat values (can repeat). Example: --stat health=35+2",
+    )
+    args = parser.parse_args()
+
+    stats = collect_stats(args)
+    progress = load_progress()
+    rules = load_rules()
+    settings = load_settings()
+
+    species_norm = normalize_species_name(args.species)
+    config = rules.get(species_norm, settings.get("default_species_template", {}))
+
+    scan = {
+        "egg": args.species,
+        "sex": args.sex,
+        "stats": stats,
+        "updated_stats": False,
+        "updated_thresholds": False,
+        "updated_stud": False,
+    }
+
+    decision, reasons = should_keep_egg(scan, config, progress)
+
+    print(f"Normalized species: {species_norm}")
+    print(f"Overall decision: {decision.upper()}")
+    for mode in ["mutations", "all_females", "stat_merge", "top_stat_females", "war"]:
+        if reasons.get(mode):
+            print(f"  ✔ would keep via {mode}")
+    for k, v in reasons.get("_debug", {}).items():
+        print(f"  debug[{k}]: {v}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `verify_rules.py` for command-line rule checking
- hook script into Script Control tab via new button

## Testing
- `python -m py_compile verify_rules.py tabs/script_control_tab.py`
- `python verify_rules.py "Therizinosaur CS Female" female --stat health=35 --stat stamina=37 --stat weight=36 --stat melee=45`
- `python verify_rules.py "Tapejara CS Male" male --stat health=48 --stat stamina=50`

------
https://chatgpt.com/codex/tasks/task_e_6843b09ac6d88321ac0b672cf926ad9b