### PR TITLE
Add progress tab with webhook summary

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -21,6 +21,7 @@ from tabs.global_tab import build_global_tab
 from tabs.species_tab import build_species_tab
 from tabs.tools_tab import build_tools_tab
 from tabs.script_control_tab import build_test_tab
+from tabs.progress_tab import build_progress_tab
 from utils.config_validator import validate_configs
 
 SETTINGS_FILE = "settings.json"
@@ -96,12 +97,14 @@ class SettingsEditor(tk.Tk):
         self.tab_global  = ttk.Frame(tabs); tabs.add(self.tab_global,  text="Global Settings")
         self.tab_species = ttk.Frame(tabs); tabs.add(self.tab_species, text="Species Config")
         self.tab_tools   = ttk.Frame(tabs); tabs.add(self.tab_tools,   text="Defaults & Tools")
+        self.tab_progress = ttk.Frame(tabs); tabs.add(self.tab_progress, text="Progress")
         self.tab_test    = ttk.Frame(tabs); tabs.add(self.tab_test,    text="Script Control")
 
         build_global_tab(self)
         build_species_tab(self)
         build_tools_tab(self)
         build_test_tab(self)
+        build_progress_tab(self)
 
     def log_message(self, msg: str):
         """Write a line to both stdout and the GUI log viewer."""

--- a/settings.json
+++ b/settings.json
@@ -12,6 +12,7 @@
   "popup_delay": 0.25,
   "action_delay": 0.05,
   "hotkey_scan": "F8",
+  "webhook_url": "",
   "debug_mode": false,
   "drop_all_button": [
     495,

--- a/tabs/progress_tab.py
+++ b/tabs/progress_tab.py
@@ -1,0 +1,86 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+import time
+import json
+from progress_tracker import load_progress, load_history
+
+FONT = ("Segoe UI", 10)
+ALL_STATS = ["health", "stamina", "weight", "melee", "oxygen", "food"]
+
+
+def build_progress_tab(app):
+    row = 0
+    ttk.Label(app.tab_progress, text="Select Species:", font=FONT).grid(row=row, column=0, sticky="w", padx=5, pady=2)
+    app.progress_species = tk.StringVar()
+    species = list(load_progress().keys())
+    app.progress_dropdown = ttk.Combobox(app.tab_progress, values=species, textvariable=app.progress_species, state="readonly", width=30)
+    app.progress_dropdown.grid(row=row, column=1, sticky="w", padx=5, pady=2)
+    row += 1
+
+    cols = ("Stat", "Top", "Threshold")
+    app.progress_tree = ttk.Treeview(app.tab_progress, columns=cols, show="headings", height=6)
+    for c in cols:
+        app.progress_tree.heading(c, text=c)
+        app.progress_tree.column(c, width=90)
+    app.progress_tree.grid(row=row, column=0, columnspan=3, padx=5, pady=5, sticky="nsew")
+    row += 1
+
+    hist_cols = ("Time", "Stat", "Value", "Type")
+    app.history_tree = ttk.Treeview(app.tab_progress, columns=hist_cols, show="headings", height=8)
+    for c in hist_cols:
+        app.history_tree.heading(c, text=c)
+        app.history_tree.column(c, width=100)
+    app.history_tree.grid(row=row, column=0, columnspan=3, padx=5, pady=5, sticky="nsew")
+    row += 1
+
+    def refresh_tables(event=None):
+        prog = load_progress()
+        hist = load_history()
+        sp = app.progress_species.get()
+        for i in app.progress_tree.get_children():
+            app.progress_tree.delete(i)
+        for st in ALL_STATS:
+            top = prog.get(sp, {}).get("top_stats", {}).get(st, "")
+            thr = prog.get(sp, {}).get("mutation_thresholds", {}).get(st, "")
+            app.progress_tree.insert("", "end", values=(st, top, thr))
+        for i in app.history_tree.get_children():
+            app.history_tree.delete(i)
+        sp_hist = hist.get(sp, {})
+        for cat in ["top_stats", "mutation_thresholds"]:
+            for st, logs in sp_hist.get(cat, {}).items():
+                for entry in logs:
+                    ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(entry.get("ts", 0)))
+                    val = entry.get("value")
+                    app.history_tree.insert("", "end", values=(ts, st, val, "top" if cat == "top_stats" else "threshold"))
+
+    app.progress_dropdown.bind("<<ComboboxSelected>>", refresh_tables)
+
+    def send_summary():
+        sp = app.progress_species.get()
+        if not sp:
+            messagebox.showwarning("No species", "Select a species first.")
+            return
+        prog = load_progress().get(sp, {})
+        lines = [f"{sp} stats:"]
+        lines.append("Top Stats:")
+        for st, val in prog.get("top_stats", {}).items():
+            lines.append(f"  {st}: {val}")
+        lines.append("Mutation Thresholds:")
+        for st, val in prog.get("mutation_thresholds", {}).items():
+            lines.append(f"  {st}: {val}")
+        msg = "\n".join(lines)
+        app.clipboard_clear()
+        app.clipboard_append(msg)
+        url = app.settings.get("webhook_url", "")
+        if url:
+            try:
+                import urllib.request
+                req = urllib.request.Request(url, data=json.dumps({"content": msg}).encode("utf-8"), headers={"Content-Type": "application/json"})
+                urllib.request.urlopen(req)
+                messagebox.showinfo("Sent", "Summary sent to Discord and copied to clipboard.")
+            except Exception as e:
+                messagebox.showerror("Error", str(e))
+        else:
+            messagebox.showinfo("Copied", "Summary copied to clipboard.")
+
+    ttk.Button(app.tab_progress, text="Copy/Send Summary", command=send_summary).grid(row=row, column=0, padx=5, pady=5, sticky="w")

--- a/utils/config_validator.py
+++ b/utils/config_validator.py
@@ -21,6 +21,7 @@ def validate_settings(settings: Dict[str, Any]) -> List[str]:
         "action_delay": (int, float),
         "hotkey_scan": str,
         "debug_mode": (bool, dict),
+        "webhook_url": str,
         "drop_all_button": list,
         "drop_all_confirm": list,
         "food_slots": list,


### PR DESCRIPTION
## Summary
- track history of stat changes in `progress_tracker`
- add new progress viewer tab to show top stats and history
- support optional webhook URL in settings and config validation

## Testing
- `pytest -q`
- `python -m py_compile progress_tracker.py tabs/progress_tab.py edit_settings.py utils/config_validator.py`


------
https://chatgpt.com/codex/tasks/task_e_6843b69ef76c832186aa3a0776bb4d5a