### PR TITLE
Add Discord bot and auto-eat utility

### DIFF
--- a/auto_eat.py
+++ b/auto_eat.py
@@ -1,0 +1,52 @@
+import json
+import time
+import random
+import threading
+from typing import Optional
+
+import pyautogui
+
+SETTINGS_FILE = "settings.json"
+
+
+def load_settings() -> dict:
+    with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def eat_food(settings: Optional[dict] = None) -> bool:
+    """Double-click one of the configured food slots."""
+    settings = settings or load_settings()
+    for x, y in settings.get("food_slots", []):
+        if pyautogui.onScreen(x, y):
+            pyautogui.doubleClick(x, y)
+            return True
+    return False
+
+
+def _auto_loop(settings: dict, stop: threading.Event) -> None:
+    while not stop.is_set():
+        eat_food(settings)
+        delay = random.uniform(120, 240)
+        for _ in range(int(delay)):
+            if stop.is_set():
+                break
+            time.sleep(1)
+
+
+def start_auto_eat(settings: Optional[dict] = None) -> threading.Event:
+    settings = settings or load_settings()
+    stop_event = threading.Event()
+    t = threading.Thread(target=_auto_loop, args=(settings, stop_event), daemon=True)
+    t.start()
+    return stop_event
+
+
+if __name__ == "__main__":
+    stop = start_auto_eat()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        stop.set()
+

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -1,0 +1,54 @@
+import os
+import json
+import time
+import asyncio
+
+import discord
+from discord.ext import commands
+import pyautogui
+
+from auto_eat import eat_food
+
+SETTINGS_FILE = "settings.json"
+
+with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
+    SETTINGS = json.load(f)
+
+BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN") or SETTINGS.get("bot_token")
+if not BOT_TOKEN:
+    raise RuntimeError("Bot token not provided via DISCORD_BOT_TOKEN or settings.json")
+
+bot = commands.Bot(command_prefix="!")
+
+
+def drop_all(settings):
+    """Click the configured drop-all button and confirm."""
+    bx, by = settings.get("drop_all_button", [0, 0])
+    cx, cy = settings.get("drop_all_confirm", [0, 0])
+    pyautogui.moveTo(bx, by)
+    pyautogui.click()
+    time.sleep(0.5)
+    pyautogui.moveTo(cx, cy)
+    pyautogui.click()
+
+
+@bot.event
+async def on_ready():
+    print(f"Logged in as {bot.user}")
+
+
+@bot.command()
+async def dropall(ctx):
+    """Drop all eggs using configured coordinates."""
+    drop_all(SETTINGS)
+    await ctx.send("🗑 Drop All executed")
+
+
+@bot.command()
+async def eatfood(ctx):
+    """Consume food from the configured slots."""
+    eat_food(SETTINGS)
+    await ctx.send("🍗 Ate one food item")
+
+
+bot.run(BOT_TOKEN)


### PR DESCRIPTION
## Summary
- add a minimal Discord bot with `!dropall` and `!eatfood` commands
- add an auto-eat helper with background thread support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c47318a88321af8d695e8346b43e