### PR TITLE
Add log pruning to GUI

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -28,6 +28,9 @@ SETTINGS_FILE = "settings.json"
 RULES_FILE    = "rules.json"
 PROGRESS_FILE = "breeding_progress.json"
 
+# maximum number of lines to retain in the on-screen log viewer
+MAX_LOG_LINES = 500
+
 DEFAULT_MODES = ["mutations", "all_females", "stat_merge", "top_stat_females", "war"]
 ALL_STATS     = ["health", "stamina", "weight", "melee", "food", "oxygen"]
 
@@ -111,6 +114,16 @@ class SettingsEditor(tk.Tk):
         try:
             if hasattr(self, "log_widget"):
                 self.log_widget.configure(state="normal")
+                try:
+                    lines = int(self.log_widget.index("end-1c").split(".")[0])
+                except Exception:
+                    lines = 0
+                while lines >= MAX_LOG_LINES:
+                    try:
+                        self.log_widget.delete("1.0", "2.0")
+                        lines = int(self.log_widget.index("end-1c").split(".")[0])
+                    except Exception:
+                        break
                 self.log_widget.insert("end", msg + "\n")
                 self.log_widget.see("end")
                 self.log_widget.configure(state="disabled")


### PR DESCRIPTION
## Summary
- keep the GUI log from growing indefinitely
- add `MAX_LOG_LINES` and prune lines in `log_message`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c9f68bc88321b91faf215e466fc5