### PR TITLE
Improve tooltips and add help tab

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -98,13 +98,16 @@ class SettingsEditor(tk.Tk):
         self.tab_species = ttk.Frame(tabs); tabs.add(self.tab_species, text="Species Config")
         self.tab_tools   = ttk.Frame(tabs); tabs.add(self.tab_tools,   text="Defaults & Tools")
         self.tab_progress = ttk.Frame(tabs); tabs.add(self.tab_progress, text="Progress")
+        self.tab_help    = ttk.Frame(tabs); tabs.add(self.tab_help,    text="Help")
         self.tab_test    = ttk.Frame(tabs); tabs.add(self.tab_test,    text="Script Control")
 
         build_global_tab(self)
         build_species_tab(self)
         build_tools_tab(self)
-        build_test_tab(self)
         build_progress_tab(self)
+        from tabs.help_tab import build_help_tab
+        build_help_tab(self)
+        build_test_tab(self)
 
     def log_message(self, msg: str):
         """Write a line to both stdout and the GUI log viewer."""

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -13,7 +13,7 @@ def build_global_tab(app):
     app.hotkey_var = tk.StringVar(value=app.settings.get("hotkey_scan", "F8"))
     entry = ttk.Entry(app.tab_global, textvariable=app.hotkey_var, width=10)
     entry.grid(row=row, column=1, sticky="w", padx=5, pady=2)
-    add_tooltip(entry, "Keyboard hotkey to start live scanning")
+    add_tooltip(entry, "Keyboard key that triggers the live scan loop")
     row += 1
 
     for delay_key in ["popup_delay", "action_delay", "scan_loop_delay"]:
@@ -32,7 +32,12 @@ def build_global_tab(app):
             width=8,
         )
         spin.grid(row=row, column=1, sticky="w", padx=5, pady=2)
-        add_tooltip(spin, f"{label} in seconds")
+        tip_map = {
+            "Popup Delay": "Time to wait after clicking before reading the popup",
+            "Action Delay": "Interval between automated mouse actions",
+            "Scan Loop Delay": "Pause between each scan cycle",
+        }
+        add_tooltip(spin, tip_map.get(label, f"{label} in seconds"))
         row += 1
 
     ttk.Label(app.tab_global, text="Per-Module Debug:", font=FONT).grid(
@@ -52,7 +57,7 @@ def build_global_tab(app):
         app.debug_vars[mod] = var
         cb = ttk.Checkbutton(app.tab_global, text=mod, variable=var)
         cb.grid(row=row, column=1, sticky="w", padx=5, pady=1)
-        add_tooltip(cb, f"Enable debug logs for {mod}")
+        add_tooltip(cb, f"Print detailed logs from the {mod} module")
         row += 1
 
     def save_all():

--- a/tabs/help_tab.py
+++ b/tabs/help_tab.py
@@ -1,0 +1,15 @@
+import tkinter as tk
+from tkinter import ttk
+
+HELP_TEXT = (
+    "1. Use 'Run Calibration' on the Tools tab to set screen positions.\n"
+    "2. Configure global options and delays in Global Settings.\n"
+    "3. Define per-species rules on the Species Config tab.\n"
+    "4. Press the configured hotkey or click Start to begin scanning.\n"
+    "5. Script Control provides manual tests and logs."
+)
+
+def build_help_tab(app):
+    lbl = ttk.Label(app.tab_help, text=HELP_TEXT, justify="left", wraplength=700)
+    lbl.pack(padx=10, pady=10, anchor="nw")
+

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -20,7 +20,7 @@ def build_test_tab(app):
 
     app.btn_start = ttk.Button(app.tab_test, text="Start Live Scanning (F8)", command=app.start_live_run)
     app.btn_start.pack(pady=5)
-    add_tooltip(app.btn_start, "Begin automated scanning using hotkey settings")
+    add_tooltip(app.btn_start, "Start the automated scan loop using current settings")
 
     app.btn_pause = ttk.Button(
         app.tab_test,
@@ -29,7 +29,7 @@ def build_test_tab(app):
         state="disabled",
     )
     app.btn_pause.pack(pady=5)
-    add_tooltip(app.btn_pause, "Temporarily halt the live scan loop")
+    add_tooltip(app.btn_pause, "Pause the live scanning loop")
 
     app.btn_resume = ttk.Button(
         app.tab_test,
@@ -38,11 +38,11 @@ def build_test_tab(app):
         state="disabled",
     )
     app.btn_resume.pack(pady=5)
-    add_tooltip(app.btn_resume, "Resume scanning if paused")
+    add_tooltip(app.btn_resume, "Resume scanning after a pause")
 
     btn = ttk.Button(app.tab_test, text="Scan Egg", command=lambda: test_scan_egg(app))
     btn.pack(pady=5)
-    add_tooltip(btn, "Single manual scan of the configured slot")
+    add_tooltip(btn, "Perform one manual scan of the configured slot")
 
     # scrolling log viewer
     app.log_widget = scrolledtext.ScrolledText(app.tab_test, height=15, state="disabled")
@@ -51,13 +51,13 @@ def build_test_tab(app):
     ttk.Label(app.tab_test, text="Testing Utilities", font=(FONT[0], FONT[1], "bold")).pack(pady=(20, 2))
     btn = ttk.Button(app.tab_test, text="Force KEEP (Real Logic)", command=app.keep_egg)
     btn.pack(pady=5)
-    add_tooltip(btn, "Invoke keep logic directly")
+    add_tooltip(btn, "Force the keep logic on the current egg")
     btn = ttk.Button(app.tab_test, text="Force DESTROY (Real Logic)", command=app.destroy_egg)
     btn.pack(pady=5)
-    add_tooltip(btn, "Invoke destroy logic directly")
+    add_tooltip(btn, "Force the destroy logic on the current egg")
     btn = ttk.Button(app.tab_test, text="Multi-Egg Scan Test", command=lambda: multi_egg_test(app))
     btn.pack(pady=10)
-    add_tooltip(btn, "Run multiple scans for debugging")
+    add_tooltip(btn, "Run repeated scans for debugging")
 
 
 

--- a/tabs/species_tab.py
+++ b/tabs/species_tab.py
@@ -27,7 +27,7 @@ def build_species_tab(app):
         width=30,
     )
     app.species_dropdown.grid(row=row, column=1, sticky="w", padx=5, pady=2)
-    add_tooltip(app.species_dropdown, "Species configuration to edit")
+    add_tooltip(app.species_dropdown, "Select the species whose rules you want to edit")
     row += 1
 
     # Checkbox vars
@@ -43,7 +43,7 @@ def build_species_tab(app):
     for mode in DEFAULT_MODES:
         cb = ttk.Checkbutton(app.tab_species, text=mode, variable=app.mode_vars[mode])
         cb.grid(row=row, column=col, sticky="w", padx=5, pady=2)
-        add_tooltip(cb, f"Enable {mode} mode")
+        add_tooltip(cb, f"Enable the {mode} mode for this species")
         col += 1
     row += 1
 
@@ -55,7 +55,7 @@ def build_species_tab(app):
     for i, stat in enumerate(ALL_STATS):
         cb = ttk.Checkbutton(sf, text=stat, variable=app.stat_vars[stat])
         cb.grid(row=i//3, column=i%3, sticky="w", padx=5, pady=1)
-        add_tooltip(cb, f"Track {stat} for merges/top/war")
+        add_tooltip(cb, f"Track {stat} when merging or rating dinos")
     row += 1
 
     ttk.Label(app.tab_species, text="Mutation Stats:", font=FONT).grid(
@@ -66,7 +66,7 @@ def build_species_tab(app):
     for i, stat in enumerate(ALL_STATS):
         cb = ttk.Checkbutton(mf, text=stat, variable=app.mutation_stat_vars[stat])
         cb.grid(row=i//3, column=i%3, sticky="w", padx=5, pady=1)
-        add_tooltip(cb, f"Watch mutations for {stat}")
+        add_tooltip(cb, f"Monitor mutations affecting {stat}")
     row += 1
 
     # Optional manual save button (can hide if you don't need it)

--- a/tabs/tools_tab.py
+++ b/tabs/tools_tab.py
@@ -13,17 +13,17 @@ def build_tools_tab(app):
     row = 0
     btn = ttk.Button(app.tab_tools, text="Run Calibration", command=run_calibration)
     btn.grid(row=row, column=0, sticky="w", padx=5, pady=2)
-    add_tooltip(btn, "Run setup_positions.py to calibrate UI coordinates")
+    add_tooltip(btn, "Launch the calibration tool to record screen positions")
     row += 1
 
     btn = ttk.Button(app.tab_tools, text="Refresh from Progress", command=lambda: refresh_species(app))
     btn.grid(row=row, column=0, sticky="w", padx=5, pady=2)
-    add_tooltip(btn, "Create rules entries from progress.json")
+    add_tooltip(btn, "Generate rules from breeding_progress.json data")
     row += 1
 
     btn = ttk.Button(app.tab_tools, text="Save All Settings", command=lambda: save_all(app))
     btn.grid(row=row, column=0, sticky="w", padx=5, pady=2)
-    add_tooltip(btn, "Write all current settings to disk")
+    add_tooltip(btn, "Save settings.json and rules.json")
     row += 2
 
     ttk.Label(app.tab_tools, text="Default Settings for New Species:", font=("Segoe UI", 10, "bold")).grid(
@@ -39,7 +39,7 @@ def build_tools_tab(app):
     for mode in DEFAULT_MODES:
         cb = ttk.Checkbutton(app.tab_tools, text=mode, variable=app.default_mode_vars[mode])
         cb.grid(row=row, column=col, sticky="w", padx=5, pady=2)
-        add_tooltip(cb, f"Default enable {mode} mode")
+        add_tooltip(cb, f"Enable {mode} mode for all new species")
         col += 1
     row += 1
 
@@ -55,7 +55,7 @@ def build_tools_tab(app):
     for i, stat in enumerate(ALL_STATS):
         cb = ttk.Checkbutton(sf, text=stat, variable=app.default_stat_vars[stat])
         cb.grid(row=i//3, column=i%3, sticky="w", padx=10, pady=2)
-        add_tooltip(cb, f"Track {stat} by default")
+        add_tooltip(cb, f"Include {stat} for new species by default")
     row += 1
 
     ttk.Label(app.tab_tools, text="Mutation Stats:", font=FONT).grid(
@@ -67,12 +67,12 @@ def build_tools_tab(app):
     for i, stat in enumerate(ALL_STATS):
         cb = ttk.Checkbutton(mf, text=stat, variable=app.default_mutation_vars[stat])
         cb.grid(row=i//3, column=i%3, sticky="w", padx=10, pady=2)
-        add_tooltip(cb, f"Default mutation stat {stat}")
+        add_tooltip(cb, f"Watch {stat} mutations for new species")
     row += 1
 
     btn = ttk.Button(app.tab_tools, text="Apply These Defaults to New Species", command=lambda: set_defaults(app))
     btn.grid(row=row, column=0, pady=10)
-    add_tooltip(btn, "Save defaults for new species to settings.json")
+    add_tooltip(btn, "Persist these defaults for future species")
 
 def run_calibration():
     try:


### PR DESCRIPTION
## Summary
- update tooltip text across all GUI tabs to be clearer
- add a simple Help tab describing usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ca011a7c8321a72ea25dacaf3cd0