### PR TITLE
Enable ttk theme setting

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -53,6 +53,9 @@ for species in progress:
 class SettingsEditor(tk.Tk):
     def __init__(self):
         super().__init__()
+        self.style = ttk.Style()
+        theme = settings.get("theme", "clam")
+        self.style.theme_use(theme)
         self.title("ARK Breeding Config Editor")
         self.geometry("750x600")
 
@@ -83,6 +86,9 @@ class SettingsEditor(tk.Tk):
 
     def save_all(self):
         """Save settings.json and rules.json from GUI state."""
+        if hasattr(self, "theme_var"):
+            self.settings["theme"] = self.theme_var.get()
+            self.style.theme_use(self.theme_var.get())
         with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
             json.dump(self.settings, f, indent=2)
         with open(RULES_FILE, "w", encoding="utf-8") as f:

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -35,6 +35,17 @@ def build_global_tab(app):
         add_tooltip(spin, f"{label} in seconds")
         row += 1
 
+    ttk.Label(app.tab_global, text="Theme", font=FONT).grid(
+        row=row, column=0, sticky="w", padx=5, pady=2
+    )
+    themes = ttk.Style().theme_names()
+    app.theme_var = tk.StringVar(value=app.settings.get("theme", "clam"))
+    cmb = ttk.Combobox(app.tab_global, textvariable=app.theme_var,
+                       values=themes, state="readonly", width=15)
+    cmb.grid(row=row, column=1, sticky="w", padx=5, pady=2)
+    add_tooltip(cmb, "Select ttk UI theme")
+    row += 1
+
     ttk.Label(app.tab_global, text="Per-Module Debug:", font=FONT).grid(
         row=row, column=0, sticky="w", padx=5, pady=(10, 2)
     )
@@ -60,6 +71,9 @@ def build_global_tab(app):
         app.settings["popup_delay"] = app.popup_delay_var.get()
         app.settings["action_delay"] = app.action_delay_var.get()
         app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
+        app.settings["theme"] = app.theme_var.get()
+        if hasattr(app, "style"):
+            app.style.theme_use(app.theme_var.get())
         app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
         with open("settings.json", "w", encoding="utf-8") as f:
             import json

--- a/tabs/tools_tab.py
+++ b/tabs/tools_tab.py
@@ -100,6 +100,10 @@ def save_all(app):
     app.settings["popup_delay"] = app.popup_delay_var.get()
     app.settings["action_delay"] = app.action_delay_var.get()
     app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
+    if hasattr(app, "theme_var"):
+        app.settings["theme"] = app.theme_var.get()
+        if hasattr(app, "style"):
+            app.style.theme_use(app.theme_var.get())
     app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
     with open("settings.json", "w", encoding="utf-8") as f:
         json.dump(app.settings, f, indent=2)

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+import importlib
+import sys
+
+def test_theme_applied(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'pyautogui', MagicMock())
+    monkeypatch.setitem(sys.modules, 'keyboard', MagicMock())
+    monkeypatch.setitem(sys.modules, 'cv2', MagicMock())
+    monkeypatch.setitem(sys.modules, 'numpy', MagicMock())
+    monkeypatch.setitem(sys.modules, 'scanner', MagicMock())
+    monkeypatch.setitem(sys.modules, 'breeding_logic', MagicMock())
+    monkeypatch.setitem(sys.modules, 'progress_tracker', MagicMock())
+    edit_settings = importlib.import_module('edit_settings')
+    # patch tkinter root methods to avoid display requirement
+    monkeypatch.setattr(edit_settings.tk.Tk, '__init__', lambda self: None)
+    monkeypatch.setattr(edit_settings.tk.Tk, 'title', lambda self, *_: None)
+    monkeypatch.setattr(edit_settings.tk.Tk, 'geometry', lambda self, *_: None)
+    # avoid side effects during init
+    monkeypatch.setattr(edit_settings.SettingsEditor, 'create_tabs', lambda self: None)
+    monkeypatch.setattr(edit_settings.SettingsEditor, 'update_hotkeys', lambda self, initial=False: None)
+    monkeypatch.setattr(edit_settings.messagebox, 'showwarning', lambda *a, **k: None)
+    # avoid StringVar requiring real root
+    monkeypatch.setattr(edit_settings.tk, 'StringVar', lambda *a, **k: MagicMock())
+    monkeypatch.setattr(edit_settings.tk, 'BooleanVar', lambda *a, **k: MagicMock())
+    monkeypatch.setattr(edit_settings.tk, 'DoubleVar', lambda *a, **k: MagicMock())
+
+    style_mock = MagicMock()
+    monkeypatch.setattr(edit_settings.ttk, 'Style', lambda: style_mock)
+    edit_settings.settings['theme'] = 'clam'
+    app = edit_settings.SettingsEditor()
+    style_mock.theme_use.assert_called_with('clam')


### PR DESCRIPTION
## Summary
- allow choosing ttk theme in SettingsEditor
- persist selected theme to settings.json from GUI
- test that SettingsEditor uses selected theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c9fb3dc0832196435fd615208011