### PR TITLE
Add tkinter theme support

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -59,6 +59,11 @@ class SettingsEditor(tk.Tk):
         super().__init__()
         self.title("ARK Breeding Config Editor")
 
+        # global ttk style/theme
+        self.style = ttk.Style(self)
+        self.style.theme_use(settings.get("theme", "clam"))
+        settings["theme"] = self.style.theme_use()
+
         # menus
         menu = tk.Menu(self)
         file_menu = tk.Menu(menu, tearoff=False)
@@ -114,6 +119,7 @@ class SettingsEditor(tk.Tk):
     def save_all(self):
         """Save settings.json and rules.json from GUI state."""
         self.save_geometry()
+        self.settings["theme"] = self.style.theme_use()
         with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
             json.dump(self.settings, f, indent=2)
         with open(RULES_FILE, "w", encoding="utf-8") as f:

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -40,6 +40,21 @@ def build_global_tab(app):
         add_tooltip(spin, tip_map.get(label, f"{label} in seconds"))
         row += 1
 
+    ttk.Label(app.tab_global, text="Theme", font=FONT).grid(
+        row=row, column=0, sticky="w", padx=5, pady=2
+    )
+    app.theme_var = tk.StringVar(value=app.settings.get("theme", "clam"))
+    theme_combo = ttk.Combobox(
+        app.tab_global,
+        textvariable=app.theme_var,
+        values=ttk.Style().theme_names(),
+        state="readonly",
+        width=12,
+    )
+    theme_combo.grid(row=row, column=1, sticky="w", padx=5, pady=2)
+    add_tooltip(theme_combo, "Select GUI theme")
+    row += 1
+
     ttk.Label(app.tab_global, text="Per-Module Debug:", font=FONT).grid(
         row=row, column=0, sticky="w", padx=5, pady=(10, 2)
     )
@@ -66,6 +81,9 @@ def build_global_tab(app):
         app.settings["action_delay"] = app.action_delay_var.get()
         app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
         app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
+        app.settings["theme"] = app.theme_var.get()
+        if hasattr(app, "style"):
+            app.style.theme_use(app.settings["theme"])
         with open("settings.json", "w", encoding="utf-8") as f:
             import json
             json.dump(app.settings, f, indent=2)

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,18 @@
+import sys
+from unittest.mock import MagicMock
+from pyvirtualdisplay import Display
+from tkinter import ttk
+
+# stub third-party modules not installed in CI
+for mod in ["pyautogui", "keyboard", "cv2", "numpy", "pytesseract"]:
+    sys.modules[mod] = MagicMock()
+
+from edit_settings import SettingsEditor, settings
+
+def test_theme_applied_to_widgets():
+    settings["theme"] = "clam"
+    with Display():
+        app = SettingsEditor()
+        style = ttk.Style(app)
+        assert style.theme_use() == "clam"
+        app.destroy()


### PR DESCRIPTION
## Summary
- allow SettingsEditor to select a ttk theme
- expose theme chooser in Global settings tab and persist it
- test that the chosen theme is applied

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843cb290b3c8321a9314605c848b36d