### PR TITLE
Add status label with live updates

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -100,6 +100,10 @@ class SettingsEditor(tk.Tk):
         # build all tabs
         self.create_tabs()
 
+        # status indicator at bottom of window
+        self.status_lbl = ttk.Label(self, text="Idle")
+        self.status_lbl.pack(side="bottom", fill="x")
+
         # hotkeys
         self.update_hotkeys(initial=True)
 
@@ -162,6 +166,11 @@ class SettingsEditor(tk.Tk):
             pass
         print(msg)
 
+    def update_status(self, msg: str):
+        """Update bottom status label."""
+        if hasattr(self, "status_lbl"):
+            self.status_lbl["text"] = msg
+
     def update_hotkeys(self, initial: bool = False):
         """Refresh global hotkeys based on current settings."""
         for h in getattr(self, "_hotkey_handles", []):
@@ -181,6 +190,7 @@ class SettingsEditor(tk.Tk):
         else:
             self.scanning_paused = bool(value)
         self.log_message("⏸ Paused" if self.scanning_paused else "▶️ Resumed")
+        self.update_status("Paused" if self.scanning_paused else "Running")
         if hasattr(self, "btn_pause") and hasattr(self, "btn_resume"):
             if self.scanning_paused:
                 self.btn_pause.config(state="disabled")
@@ -199,6 +209,7 @@ class SettingsEditor(tk.Tk):
         self._summary = {"studs": [], "mutations": []}
         self.live_running = True
         self.scanning_paused = False
+        self.update_status("Running")
 
         def run_loop():
             self.log_message("▶️ Live scanning started (F8 to run, F9 to pause/resume, ESC to exit)")
@@ -332,6 +343,7 @@ class SettingsEditor(tk.Tk):
     def quit(self):
         """On ESC: write summary.log then close."""
         self.log_message("🛑 ESC pressed — quitting application.")
+        self.update_status("Stopped")
         self.save_geometry()
         with open("summary.log", "w", encoding="utf-8") as f:
             f.write("=== STUDS UPDATED (tracked only) ===\n")


### PR DESCRIPTION
## Summary
- add a bottom status label in the main window
- implement `update_status` utility
- update status during run, pause/resume, and quit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843cb13ad708321bc4add0578aec2bc