### PR TITLE
Add dialogs helper and refactor alerts

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -6,7 +6,8 @@ import subprocess
 import pyautogui
 import keyboard
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import ttk
+from utils.dialogs import show_error, show_warning, show_info
 import webbrowser
 
 from scanner import scan_slot
@@ -105,7 +106,7 @@ class SettingsEditor(tk.Tk):
 
         warnings = validate_configs(self.settings, self.rules, self.progress)
         if warnings:
-            messagebox.showwarning("Config Warnings", "\n".join(warnings))
+            show_warning("Config Warnings", "\n".join(warnings))
 
     def save_geometry(self):
         """Store current window geometry into settings."""
@@ -118,7 +119,7 @@ class SettingsEditor(tk.Tk):
             json.dump(self.settings, f, indent=2)
         with open(RULES_FILE, "w", encoding="utf-8") as f:
             json.dump(self.rules, f, indent=2)
-        messagebox.showinfo("Saved", "Settings and rules have been saved.")
+        show_info("Saved", "Settings and rules have been saved.")
 
     def create_tabs(self):
         """Construct the Notebook and attach each tab’s builder."""

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from tkinter import ttk
+from utils.dialogs import show_info
 
 from utils.helpers import add_tooltip
 
@@ -69,7 +70,7 @@ def build_global_tab(app):
         with open("settings.json", "w", encoding="utf-8") as f:
             import json
             json.dump(app.settings, f, indent=2)
-        tk.messagebox.showinfo("Saved", "Global settings saved.")
+        show_info("Saved", "Global settings saved.")
         if hasattr(app, "update_hotkeys"):
             app.update_hotkeys()
 

--- a/tabs/progress_tab.py
+++ b/tabs/progress_tab.py
@@ -1,5 +1,6 @@
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import ttk
+from utils.dialogs import show_error, show_warning, show_info
 import time
 import json
 from progress_tracker import load_progress, load_history
@@ -58,7 +59,7 @@ def build_progress_tab(app):
     def send_summary():
         sp = app.progress_species.get()
         if not sp:
-            messagebox.showwarning("No species", "Select a species first.")
+            show_warning("No species", "Select a species first.")
             return
         prog = load_progress().get(sp, {})
         lines = [f"{sp} stats:"]
@@ -77,10 +78,10 @@ def build_progress_tab(app):
                 import urllib.request
                 req = urllib.request.Request(url, data=json.dumps({"content": msg}).encode("utf-8"), headers={"Content-Type": "application/json"})
                 urllib.request.urlopen(req)
-                messagebox.showinfo("Sent", "Summary sent to Discord and copied to clipboard.")
+                show_info("Sent", "Summary sent to Discord and copied to clipboard.")
             except Exception as e:
-                messagebox.showerror("Error", str(e))
+                show_error("Error", str(e))
         else:
-            messagebox.showinfo("Copied", "Summary copied to clipboard.")
+            show_info("Copied", "Summary copied to clipboard.")
 
     ttk.Button(app.tab_progress, text="Copy/Send Summary", command=send_summary).grid(row=row, column=0, padx=5, pady=5, sticky="w")

--- a/tabs/species_tab.py
+++ b/tabs/species_tab.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
+from utils.dialogs import show_error, show_warning, show_info
 
 from utils.helpers import refresh_species_dropdown, add_tooltip
 
@@ -112,7 +113,7 @@ def load_species_config(app):
 def save_species_config(app):
     s = app.selected_species.get()
     if not s:
-        messagebox.showwarning("No species", "Select a species first.")
+        show_warning("No species", "Select a species first.")
         return
     app.rules[s] = {
         "modes": [m for m, var in app.mode_vars.items() if var.get()],
@@ -123,12 +124,12 @@ def save_species_config(app):
     }
     with open("rules.json", "w", encoding="utf-8") as f:
         json.dump(app.rules, f, indent=2)
-    messagebox.showinfo("Saved", f"Settings for {s} updated.")
+    show_info("Saved", f"Settings for {s} updated.")
 
 def delete_species(app):
     s = app.selected_species.get()
     if not s:
-        messagebox.showwarning("No species", "Select a species first.")
+        show_warning("No species", "Select a species first.")
         return
     if not messagebox.askyesno("Confirm", f"Delete configuration for {s}?"):
         return

--- a/tabs/tools_tab.py
+++ b/tabs/tools_tab.py
@@ -1,5 +1,6 @@
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import ttk
+from utils.dialogs import show_error, show_warning, show_info
 import json
 import subprocess
 from utils.helpers import refresh_species_dropdown, add_tooltip
@@ -78,7 +79,7 @@ def run_calibration():
     try:
         subprocess.run(["python", "setup_positions.py"], check=True)
     except Exception as e:
-        messagebox.showerror("Error", str(e))
+        show_error("Error", str(e))
 
 def refresh_species(app):
     from progress_tracker import load_progress
@@ -93,7 +94,7 @@ def refresh_species(app):
         json.dump(app.rules, f, indent=2)
     from utils.helpers import refresh_species_dropdown
     refresh_species_dropdown(app)
-    messagebox.showinfo("Refreshed", f"Added {new_added} new species.")
+    show_info("Refreshed", f"Added {new_added} new species.")
 
 def save_all(app):
     app.settings["hotkey_scan"] = app.hotkey_var.get()
@@ -103,7 +104,7 @@ def save_all(app):
     app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
     with open("settings.json", "w", encoding="utf-8") as f:
         json.dump(app.settings, f, indent=2)
-    messagebox.showinfo("Saved", "All settings saved.")
+    show_info("Saved", "All settings saved.")
 
 def set_defaults(app):
     app.settings["default_species_template"] = {
@@ -115,4 +116,4 @@ def set_defaults(app):
     }
     with open("settings.json", "w", encoding="utf-8") as f:
         json.dump(app.settings, f, indent=2)
-    messagebox.showinfo("Defaults Saved", "Defaults for new species saved.")
+    show_info("Defaults Saved", "Defaults for new species saved.")

--- a/utils/dialogs.py
+++ b/utils/dialogs.py
@@ -1,0 +1,15 @@
+import tkinter.messagebox as messagebox
+
+def show_error(title: str, message: str) -> None:
+    """Display an error message dialog."""
+    messagebox.showerror(title, message)
+
+
+def show_warning(title: str, message: str) -> None:
+    """Display a warning message dialog."""
+    messagebox.showwarning(title, message)
+
+
+def show_info(title: str, message: str) -> None:
+    """Display an informational message dialog."""
+    messagebox.showinfo(title, message)


### PR DESCRIPTION
## Summary
- centralize Tk message dialogs in `utils.dialogs`
- refactor GUI modules to use the helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843cb6a595483219737d9883b8c3360