### PR TITLE
Handle missing settings.json in logger

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -2,9 +2,13 @@ import logging
 import json
 
 # load your settings once
-with open("settings.json", encoding="utf-8") as f:
-    cfg = json.load(f)
-debug_flags = cfg.get("debug_mode", {})
+try:
+    with open("settings.json", encoding="utf-8") as f:
+        cfg = json.load(f)
+except FileNotFoundError:
+    cfg = {}
+
+debug_flags = cfg.get("debug_mode", False)
 
 def get_logger(module_name: str) -> logging.Logger:
     # if debug_flags is a dict, look up per-module;

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import importlib
+import logging
+from unittest import TestCase
+
+class LoggerWithoutSettingsTest(TestCase):
+    def test_logger_works_without_settings_file(self):
+        # Temporarily rename settings.json if it exists
+        settings_file = 'settings.json'
+        backup_file = settings_file + '.bak'
+        restored = False
+        if os.path.exists(settings_file):
+            os.rename(settings_file, backup_file)
+            restored = True
+        try:
+            if 'logger' in sys.modules:
+                del sys.modules['logger']
+            logger = importlib.import_module('logger')
+            log = logger.get_logger('some_module')
+            self.assertIsInstance(log, logging.Logger)
+        finally:
+            if restored:
+                os.rename(backup_file, settings_file)
+                if 'logger' in sys.modules:
+                    del sys.modules['logger']
+


### PR DESCRIPTION
## Summary
- protect logger settings load with try/except
- default to debug mode off if settings.json is missing
- add unit test covering logger import when settings.json doesn't exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444dd391c4832194e64c703235c59c