### PR TITLE
Add progress tracker tests

### DIFF
--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -1,0 +1,71 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import progress_tracker
+
+
+def test_update_top_stats_records_new_value():
+    progress = {}
+    with patch('progress_tracker.normalize_species_name', return_value='Rex'), \
+         patch('progress_tracker.record_history') as rec:
+        updated = progress_tracker.update_top_stats('egg', {'melee': {'base': 5}}, progress)
+    assert updated is True
+    assert progress['Rex']['top_stats']['melee'] == 5
+    rec.assert_called_once_with('Rex', 'top_stats', 'melee', 5)
+
+
+def test_update_top_stats_no_change():
+    progress = {'Rex': {'top_stats': {'melee': 5}, 'mutation_thresholds': {}, 'stud': {}, 'female_count': 0}}
+    with patch('progress_tracker.normalize_species_name', return_value='Rex'), \
+         patch('progress_tracker.record_history') as rec:
+        updated = progress_tracker.update_top_stats('egg', {'melee': {'base': 4}}, progress)
+    assert updated is False
+    assert progress['Rex']['top_stats']['melee'] == 5
+    rec.assert_not_called()
+
+
+def test_increment_female_count_when_female():
+    progress = {}
+    with patch('progress_tracker.normalize_species_name', return_value='Rex'):
+        count = progress_tracker.increment_female_count('egg', progress, 'female')
+    assert count == 1
+    assert progress['Rex']['female_count'] == 1
+
+
+def test_increment_female_count_when_not_female():
+    progress = {}
+    with patch('progress_tracker.normalize_species_name', return_value='Rex'):
+        count = progress_tracker.increment_female_count('egg', progress, 'male')
+    assert count == 0
+    assert progress == {}
+
+
+def test_adjust_rules_for_females_new_species_with_template():
+    progress = {}
+    rules = {}
+    template = {"modes": []}
+    with patch('progress_tracker.log'):
+        changed = progress_tracker.adjust_rules_for_females('Rex', progress, rules, template)
+    assert changed is True
+    assert set(rules['Rex']['modes']) == {'mutations', 'stat_merge', 'all_females'}
+
+
+def test_adjust_rules_for_females_medium_count():
+    progress = {'Rex': {'female_count': 50}}
+    rules = {'Rex': {'modes': ['all_females']}}
+    with patch('progress_tracker.log'):
+        changed = progress_tracker.adjust_rules_for_females('Rex', progress, rules)
+    assert changed is True
+    assert set(rules['Rex']['modes']) == {'mutations', 'stat_merge', 'top_stat_females'}
+
+
+def test_adjust_rules_for_females_high_count():
+    progress = {'Rex': {'female_count': 150}}
+    rules = {'Rex': {'modes': ['all_females', 'top_stat_females']}}
+    with patch('progress_tracker.log'):
+        changed = progress_tracker.adjust_rules_for_females('Rex', progress, rules)
+    assert changed is True
+    assert set(rules['Rex']['modes']) == {'mutations', 'stat_merge'}


### PR DESCRIPTION
## Summary
- test `update_top_stats` new and unchanged values
- test female count incrementer
- test rule adjustments based on female counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444dd8e9f083219ab38fff62e505f1