### PR TITLE
Implement automated breeding mode and rescan behavior

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -60,7 +60,7 @@ progress = (
 )
 
 default_species_template = settings.get("default_species_template", {
-    "modes": ["mutations", "all_females"],
+    "modes": ["mutations", "all_females", "stat_merge", "top_stat_females", "war", "automated"],
     "mutation_stats": ["health", "melee"],
     "stat_merge_stats": ["health", "melee", "stamina"],
     "top_stat_females_stats": ["health", "melee", "stamina"],

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -166,22 +166,27 @@ def adjust_rules_for_females(species, progress, rules, default_template=None):
             rules[species] = default_template.copy()
         else:
             return False
+        modes = set(rules[species].get("modes", []))
+        modes.add("automated")
+        rules[species]["modes"] = list(modes)
 
     ensure_species(progress, species)
     count = progress[species].get("female_count", 0)
     modes = set(rules[species].get("modes", []))
     before = modes.copy()
 
-    if count < 30:
-        modes.update({"mutations", "stat_merge", "all_females"})
-        modes.discard("top_stat_females")
-    elif count < 100:
-        modes.update({"mutations", "stat_merge", "top_stat_females"})
-        modes.discard("all_females")
-    else:
-        modes.update({"mutations", "stat_merge"})
-        modes.discard("all_females")
-        modes.discard("top_stat_females")
+    if "automated" in modes:
+        if count < 30:
+            modes.update({"mutations", "stat_merge", "all_females"})
+            modes.discard("top_stat_females")
+        elif count < 96:
+            modes.update({"mutations", "stat_merge", "top_stat_females"})
+            modes.discard("all_females")
+        else:
+            modes.update({"mutations", "stat_merge"})
+            modes.discard("all_females")
+            modes.discard("top_stat_females")
+            modes.discard("automated")
 
     if modes != before:
         rules[species]["modes"] = list(modes)

--- a/settings.json
+++ b/settings.json
@@ -92,7 +92,8 @@
       "all_females",
       "stat_merge",
       "top_stat_females",
-      "war"
+      "war",
+      "automated"
     ],
     "mutation_stats": [
       "health",

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -50,21 +50,21 @@ def test_adjust_rules_for_females_new_species_with_template():
     with patch('progress_tracker.log'):
         changed = progress_tracker.adjust_rules_for_females('Rex', progress, rules, template)
     assert changed is True
-    assert set(rules['Rex']['modes']) == {'mutations', 'stat_merge', 'all_females'}
+    assert set(rules['Rex']['modes']) == {'mutations', 'stat_merge', 'all_females', 'automated'}
 
 
 def test_adjust_rules_for_females_medium_count():
     progress = {'Rex': {'female_count': 50}}
-    rules = {'Rex': {'modes': ['all_females']}}
+    rules = {'Rex': {'modes': ['all_females', 'automated']}}
     with patch('progress_tracker.log'):
         changed = progress_tracker.adjust_rules_for_females('Rex', progress, rules)
     assert changed is True
-    assert set(rules['Rex']['modes']) == {'mutations', 'stat_merge', 'top_stat_females'}
+    assert set(rules['Rex']['modes']) == {'mutations', 'stat_merge', 'top_stat_females', 'automated'}
 
 
 def test_adjust_rules_for_females_high_count():
     progress = {'Rex': {'female_count': 150}}
-    rules = {'Rex': {'modes': ['all_females', 'top_stat_females']}}
+    rules = {'Rex': {'modes': ['all_females', 'top_stat_females', 'automated']}}
     with patch('progress_tracker.log'):
         changed = progress_tracker.adjust_rules_for_females('Rex', progress, rules)
     assert changed is True


### PR DESCRIPTION
## Summary
- add rescan path for invalid species OCR
- allow keeping males with equal mutations but better base stats
- introduce automated breeding mode with new thresholds
- update default species template to include automated mode
- adjust unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445dce63ac8321b8b2c45b3b961713