### PR TITLE
Use deepcopy for new species templates

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -7,6 +7,7 @@ import pyautogui
 import keyboard
 import tkinter as tk
 from tkinter import ttk
+from copy import deepcopy
 from utils.dialogs import show_error, show_warning, show_info
 import webbrowser
 
@@ -70,7 +71,7 @@ default_species_template = settings.get("default_species_template", {
 # ensure every species in progress has a rules entry
 for species in progress:
     if species not in rules:
-        rules[species] = default_species_template.copy()
+        rules[species] = deepcopy(default_species_template)
 
 # ─── Main GUI ─────────────────────────────────────────────────────
 class SettingsEditor(tk.Tk):

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import time
+from copy import deepcopy
 from difflib import get_close_matches
 
 HISTORY_FILE = "progress_history.json"
@@ -23,7 +24,7 @@ DEFAULT_PROGRESS_TEMPLATE = {
 def ensure_species(progress, species):
     """Ensure a species entry exists with all required keys."""
     if species not in progress:
-        progress[species] = DEFAULT_PROGRESS_TEMPLATE.copy()
+        progress[species] = deepcopy(DEFAULT_PROGRESS_TEMPLATE)
     else:
         for k, v in DEFAULT_PROGRESS_TEMPLATE.items():
             progress[species].setdefault(k, v if isinstance(v, dict) else 0)
@@ -163,7 +164,7 @@ def adjust_rules_for_females(species, progress, rules, default_template=None):
     """Adjust breeding rules based on female counts."""
     if species not in rules:
         if default_template:
-            rules[species] = default_template.copy()
+            rules[species] = deepcopy(default_template)
         else:
             return False
         modes = set(rules[species].get("modes", []))

--- a/tabs/tools_tab.py
+++ b/tabs/tools_tab.py
@@ -4,6 +4,7 @@ from utils.dialogs import show_error, show_warning, show_info
 import json
 import subprocess
 from utils.helpers import refresh_species_dropdown, add_tooltip
+from copy import deepcopy
 
 FONT = ("Segoe UI", 10)
 
@@ -88,7 +89,7 @@ def refresh_species(app):
     default = app.settings.get("default_species_template", {})
     for species in progress:
         if species not in app.rules:
-            app.rules[species] = default.copy()
+            app.rules[species] = deepcopy(default)
             new_added += 1
     with open("rules.json", "w", encoding="utf-8") as f:
         json.dump(app.rules, f, indent=2)


### PR DESCRIPTION
## Summary
- ensure new species progress and rules templates are deep copied
- apply same fix for rules refreshed from tools tab
- update imports accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684472934aa08321aa68f568ee514287