### PR TITLE
Implement new settings and progress display

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -67,6 +67,9 @@ default_species_template = settings.get("default_species_template", {
 for species in progress:
     if species not in rules:
         rules[species] = deepcopy(default_species_template)
+        modes = set(rules[species].get("modes", []))
+        modes.add("automated")
+        rules[species]["modes"] = list(modes)
 
 # ─── Main GUI ─────────────────────────────────────────────────────
 class SettingsEditor(tk.Tk):

--- a/settings.json
+++ b/settings.json
@@ -12,6 +12,7 @@
   "popup_delay": 0.25,
   "action_delay": 0.05,
   "hotkey_scan": "F8",
+  "auto_eat_enabled": false,
   "webhook_url": "",
   "debug_mode": false,
   "drop_all_button": [

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -74,6 +74,12 @@ def build_global_tab(app):
     add_tooltip(theme_combo, "Select GUI theme")
     row += 1
 
+    app.auto_eat_var = tk.BooleanVar(value=app.settings.get("auto_eat_enabled", False))
+    cb_auto = ttk.Checkbutton(app.tab_global, text="Enable Auto-Eat", variable=app.auto_eat_var)
+    cb_auto.grid(row=row, column=0, columnspan=2, sticky="w", padx=5, pady=2)
+    add_tooltip(cb_auto, "Automatically consume food periodically")
+    row += 1
+
     ttk.Label(app.tab_global, text="Per-Module Debug:", font=FONT).grid(
         row=row, column=0, sticky="w", padx=5, pady=(10, 2)
     )
@@ -99,6 +105,7 @@ def build_global_tab(app):
         app.settings["popup_delay"] = app.popup_delay_var.get()
         app.settings["action_delay"] = app.action_delay_var.get()
         app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
+        app.settings["auto_eat_enabled"] = app.auto_eat_var.get()
         app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
         app.settings["theme"] = app.theme_var.get()
         app.settings["current_wipe"] = app.wipe_var.get() or "default"

--- a/tabs/progress_tab.py
+++ b/tabs/progress_tab.py
@@ -16,6 +16,8 @@ def build_progress_tab(app):
     species = list(load_progress(app.settings.get("current_wipe", "default")).keys())
     app.progress_dropdown = ttk.Combobox(app.tab_progress, values=species, textvariable=app.progress_species, state="readonly", width=30)
     app.progress_dropdown.grid(row=row, column=1, sticky="w", padx=5, pady=2)
+    app.female_count_var = tk.StringVar()
+    ttk.Label(app.tab_progress, textvariable=app.female_count_var, font=FONT).grid(row=row, column=2, sticky="w", padx=5, pady=2)
     row += 1
 
     cols = ("Stat", "Top", "Threshold")
@@ -38,6 +40,8 @@ def build_progress_tab(app):
         prog = load_progress(app.settings.get("current_wipe", "default"))
         hist = load_history(app.settings.get("current_wipe", "default"))
         sp = app.progress_species.get()
+        count = prog.get(sp, {}).get("female_count", 0)
+        app.female_count_var.set(f"Females: {count}")
         for i in app.progress_tree.get_children():
             app.progress_tree.delete(i)
         for st in ALL_STATS:
@@ -63,6 +67,7 @@ def build_progress_tab(app):
             return
         prog = load_progress(app.settings.get("current_wipe", "default")).get(sp, {})
         lines = [f"{sp} stats:"]
+        lines.append(f"Females: {prog.get('female_count', 0)}")
         lines.append("Top Stats:")
         for st, val in prog.get("top_stats", {}).items():
             lines.append(f"  {st}: {val}")


### PR DESCRIPTION
## Summary
- add automated mode when initializing new species
- support auto-eat toggle in global settings tab
- display female counts in progress tab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b4a6991083218e1bb13a3a8690ac