### PR TITLE
Add mutation stud tracking

### DIFF
--- a/breeding_logic.py
+++ b/breeding_logic.py
@@ -84,7 +84,7 @@ def should_keep_egg(scan, rules, progress):
                 any_strict = True
                 reasons.append(f"{st}={egg_mut}>{th}")
             else:
-                stud_base = progress.get(species, {}).get("stud", {}).get(st, 0)
+                stud_base = progress.get(species, {}).get("mutation_stud", {}).get(st, 0)
                 egg_base = stats.get(st, {}).get("base", 0)
                 if egg_base > stud_base:
                     better_base = True

--- a/edit_settings.py
+++ b/edit_settings.py
@@ -15,7 +15,8 @@ from scanner import scan_slot
 from breeding_logic import should_keep_egg
 from progress_tracker import (
     load_progress, save_progress,
-    update_top_stats, update_mutation_thresholds, update_stud,
+    update_top_stats, update_mutation_thresholds,
+    update_stud, update_mutation_stud,
     increment_female_count, adjust_rules_for_females,
     normalize_species_name
 )
@@ -295,6 +296,11 @@ class SettingsEditor(tk.Tk):
                     if sex == "male"
                     else False
                 )
+                updated_mstud = (
+                    update_mutation_stud(egg, stats, config, progress)
+                    if sex == "male"
+                    else False
+                )
 
                 # record for summary
                 if updated_thresholds:
@@ -310,7 +316,8 @@ class SettingsEditor(tk.Tk):
                     "stats": stats,
                     "updated_stats": updated_stats,
                     "updated_thresholds": updated_thresholds,
-                    "updated_stud": updated_stud
+                    "updated_stud": updated_stud,
+                    "updated_mutation_stud": updated_mstud
                 })
                 save_progress(progress, self.settings.get("current_wipe", "default"))
                 # print UI feedback

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -19,6 +19,7 @@ DEFAULT_PROGRESS_TEMPLATE = {
     "top_stats": {},
     "mutation_thresholds": {},
     "stud": {},
+    "mutation_stud": {},
     "female_count": 0,
 }
 
@@ -176,6 +177,30 @@ def update_stud(egg, scan_stats, config, progress):
         return True
 
     return False
+
+def update_mutation_stud(egg, scan_stats, config, progress):
+    """Update mutation stud bases when mutations equal thresholds."""
+    s = normalize_species_name(egg)
+    ensure_species(progress, s)
+
+    mutation_stats = config.get("mutation_stats", [])
+    thresholds = progress[s].get("mutation_thresholds", {})
+    mstud = progress[s].get("mutation_stud", {})
+
+    updated = False
+
+    for stat in mutation_stats:
+        mut = scan_stats.get(stat, {}).get("mutation", 0)
+        base = scan_stats.get(stat, {}).get("base", 0)
+        thresh = thresholds.get(stat, 0)
+        if mut == thresh and base > mstud.get(stat, 0):
+            log.info(
+                f"New mutation stud for {s} {stat}: base {base} at {mut} mutations"
+            )
+            progress[s].setdefault("mutation_stud", {})[stat] = base
+            updated = True
+
+    return updated
 
 def increment_female_count(egg, progress, sex):
     """Increment female count for a species if sex is female."""

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -11,7 +11,8 @@ __test__ = False
 from breeding_logic import should_keep_egg
 from progress_tracker import (
     load_progress, save_progress,
-    update_top_stats, update_mutation_thresholds, update_stud,
+    update_top_stats, update_mutation_thresholds,
+    update_stud, update_mutation_stud,
     normalize_species_name
 )
 
@@ -83,6 +84,7 @@ def test_scan_egg(app):
     update_mutation_thresholds(egg, stats, config, progress, sex)
     if sex == "male":
         update_stud(egg, stats, config, progress)
+        update_mutation_stud(egg, stats, config, progress)
 
     scan.update({
         "egg": egg,
@@ -90,7 +92,8 @@ def test_scan_egg(app):
         "stats": stats,
         "updated_stats": update_top_stats(egg, stats, progress),
         "updated_thresholds": update_mutation_thresholds(egg, stats, config, progress, sex),
-        "updated_stud": update_stud(egg, stats, config, progress) if sex == "male" else False
+        "updated_stud": update_stud(egg, stats, config, progress) if sex == "male" else False,
+        "updated_mutation_stud": update_mutation_stud(egg, stats, config, progress) if sex == "male" else False
     })
 
     decision, reasons = should_keep_egg(scan, config, progress)
@@ -138,6 +141,7 @@ def multi_egg_test(app):
         update_mutation_thresholds(egg, stats, config, progress, sex)
         if sex == "male":
             update_stud(egg, stats, config, progress)
+            update_mutation_stud(egg, stats, config, progress)
 
         scan.update({
             "egg": egg,
@@ -145,7 +149,8 @@ def multi_egg_test(app):
             "stats": stats,
             "updated_stats": update_top_stats(egg, stats, progress),
             "updated_thresholds": update_mutation_thresholds(egg, stats, config, progress, sex),
-            "updated_stud": update_stud(egg, stats, config, progress) if sex == "male" else False
+            "updated_stud": update_stud(egg, stats, config, progress) if sex == "male" else False,
+            "updated_mutation_stud": update_mutation_stud(egg, stats, config, progress) if sex == "male" else False
         })
 
         decision, reasons = should_keep_egg(scan, config, progress)

--- a/tests/test_breeding_logic.py
+++ b/tests/test_breeding_logic.py
@@ -47,7 +47,7 @@ class ShouldKeepEggTests(TestCase):
         progress = {
             "TestDino": {
                 "mutation_thresholds": {"melee": 2},
-                "stud": {"melee": 5},
+                "mutation_stud": {"melee": 5},
             }
         }
         with patch("breeding_logic.normalize_species_name", return_value="TestDino"):

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -69,3 +69,18 @@ def test_adjust_rules_for_females_high_count():
         changed = progress_tracker.adjust_rules_for_females('Rex', progress, rules)
     assert changed is True
     assert set(rules['Rex']['modes']) == {'mutations', 'stat_merge'}
+
+
+def test_update_mutation_stud_updates_value():
+    progress = {
+        'Rex': {
+            'mutation_thresholds': {'melee': 2},
+            'mutation_stud': {'melee': 5}
+        }
+    }
+    config = {'mutation_stats': ['melee']}
+    stats = {'melee': {'mutation': 2, 'base': 6}}
+    with patch('progress_tracker.normalize_species_name', return_value='Rex'):
+        updated = progress_tracker.update_mutation_stud('egg', stats, config, progress)
+    assert updated is True
+    assert progress['Rex']['mutation_stud']['melee'] == 6


### PR DESCRIPTION
## Summary
- track mutation stud info in progress tracking
- update breeding logic to compare against mutation stud
- import and call new mutation stud function in scripts
- adapt tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b4b6d1388321839d6118beeade17