### PR TITLE
Add auto-eat toggle

### DIFF
--- a/auto_eat.py
+++ b/auto_eat.py
@@ -34,8 +34,11 @@ def _auto_loop(settings: dict, stop: threading.Event) -> None:
             time.sleep(1)
 
 
-def start_auto_eat(settings: Optional[dict] = None) -> threading.Event:
+def start_auto_eat(settings: Optional[dict] = None) -> Optional[threading.Event]:
     settings = settings or load_settings()
+    if not settings.get("auto_eat_enabled", False):
+        return None
+
     stop_event = threading.Event()
     t = threading.Thread(
         target=_auto_loop,

--- a/settings.json
+++ b/settings.json
@@ -14,6 +14,7 @@
   "hotkey_scan": "F8",
   "webhook_url": "",
   "debug_mode": false,
+  "auto_eat_enabled": false,
   "drop_all_button": [
     495,
     196

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -74,6 +74,12 @@ def build_global_tab(app):
     add_tooltip(theme_combo, "Select GUI theme")
     row += 1
 
+    app.auto_eat_var = tk.BooleanVar(value=app.settings.get("auto_eat_enabled", False))
+    cb = ttk.Checkbutton(app.tab_global, text="Enable Auto Eat", variable=app.auto_eat_var)
+    cb.grid(row=row, column=1, sticky="w", padx=5, pady=2)
+    add_tooltip(cb, "Periodically feed using configured slots")
+    row += 1
+
     ttk.Label(app.tab_global, text="Per-Module Debug:", font=FONT).grid(
         row=row, column=0, sticky="w", padx=5, pady=(10, 2)
     )
@@ -101,6 +107,7 @@ def build_global_tab(app):
         app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
         app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
         app.settings["theme"] = app.theme_var.get()
+        app.settings["auto_eat_enabled"] = app.auto_eat_var.get()
         app.settings["current_wipe"] = app.wipe_var.get() or "default"
         ensure_wipe_dir(app.settings["current_wipe"])
         if hasattr(app, "style"):


### PR DESCRIPTION
## Summary
- add `auto_eat_enabled` flag to settings
- gate `start_auto_eat` on the new flag
- expose checkbox in global tab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b4bb623483219d5f075cce6d8531