### PR TITLE
Fix progress loading and species updates per wipe

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -264,6 +264,14 @@ class SettingsEditor(tk.Tk):
                     normalized, self.settings.get("default_species_template", {})
                 )
                 progress = load_progress(self.settings.get("current_wipe", "default"))
+                new_species = normalized not in progress
+                if new_species and normalized not in self.rules:
+                    from copy import deepcopy
+                    self.rules[normalized] = deepcopy(self.settings.get("default_species_template", {}))
+                    with open(RULES_FILE, "w", encoding="utf-8") as f:
+                        json.dump(self.rules, f, indent=2)
+                    from utils.helpers import refresh_species_dropdown
+                    refresh_species_dropdown(self)
 
                 # Step 1: update top‐stats
                 updated_stats = update_top_stats(egg, stats, progress)

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -50,12 +50,23 @@ def ensure_species(progress, species):
             progress[species].setdefault(k, v if isinstance(v, dict) else 0)
 
 def load_progress(wipe: str = "default"):
-    path = get_progress_file(wipe)
+    """Load progress data, initializing the file if necessary."""
     ensure_wipe_dir(wipe)
-    if os.path.exists(path):
-        with open(path, "r", encoding="utf-8") as f:
+    path = get_progress_file(wipe)
+
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({}, f)
+        return {}
+
+    with open(path, "r", encoding="utf-8") as f:
+        try:
             return json.load(f)
-    return {}
+        except json.JSONDecodeError:
+            # Corrupted file, reset to empty
+            with open(path, "w", encoding="utf-8") as wf:
+                json.dump({}, wf)
+            return {}
 
 def save_progress(data, wipe: str = "default"):
     ensure_wipe_dir(wipe)

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -93,8 +93,12 @@ def build_global_tab(app):
         app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
         app.settings["auto_eat_enabled"] = app.auto_eat_var.get()
         app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
+        old_wipe = app.settings.get("current_wipe", "default")
         app.settings["current_wipe"] = app.wipe_var.get() or "default"
         ensure_wipe_dir(app.settings["current_wipe"])
+        if app.settings["current_wipe"] != old_wipe:
+            from utils.helpers import refresh_species_dropdown
+            refresh_species_dropdown(app)
         with open("settings.json", "w", encoding="utf-8") as f:
             import json
             json.dump(app.settings, f, indent=2)

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -79,6 +79,14 @@ def test_scan_egg(app):
 
     config = app.rules.get(normalized, app.settings.get("default_species_template", {}))
     progress = load_progress(app.settings.get("current_wipe", "default"))
+    new_species = normalized not in progress
+    if new_species and normalized not in app.rules:
+        from copy import deepcopy
+        app.rules[normalized] = deepcopy(app.settings.get("default_species_template", {}))
+        with open("rules.json", "w", encoding="utf-8") as f:
+            json.dump(app.rules, f, indent=2)
+        from utils.helpers import refresh_species_dropdown
+        refresh_species_dropdown(app)
 
     update_top_stats(egg, stats, progress)
     update_mutation_thresholds(egg, stats, config, progress, sex)
@@ -137,6 +145,14 @@ def multi_egg_test(app):
         normalized = normalize_species_name(egg)
 
         config = app.rules.get(normalized, app.settings.get("default_species_template", {}))
+        new_species = normalized not in progress
+        if new_species and normalized not in app.rules:
+            from copy import deepcopy
+            app.rules[normalized] = deepcopy(app.settings.get("default_species_template", {}))
+            with open("rules.json", "w", encoding="utf-8") as f:
+                json.dump(app.rules, f, indent=2)
+            from utils.helpers import refresh_species_dropdown
+            refresh_species_dropdown(app)
         update_top_stats(egg, stats, progress)
         update_mutation_thresholds(egg, stats, config, progress, sex)
         if sex == "male":

--- a/tabs/species_tab.py
+++ b/tabs/species_tab.py
@@ -21,7 +21,9 @@ def build_species_tab(app):
     # Track last-loaded species for autosave
     app._last_species = None
 
-    # populate dropdown from progress data so switching wipes updates correctly
+    # populate dropdown using only the currently selected wipe's progress
+    from progress_tracker import load_progress
+    app.progress = load_progress(app.settings.get("current_wipe", "default"))
     app.species_list = sorted(app.progress.keys())
     app.species_dropdown = ttk.Combobox(
         app.tab_species,

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -3,7 +3,12 @@ from tkinter import ttk
 
 
 def refresh_species_dropdown(app):
-    """Update the species combobox with keys from ``app.progress``."""
+    """Reload progress for the current wipe and refresh the species combobox."""
+    from progress_tracker import load_progress
+
+    if hasattr(app, "settings"):
+        app.progress = load_progress(app.settings.get("current_wipe", "default"))
+
     if hasattr(app, "species_dropdown"):
         app.species_dropdown["values"] = sorted(app.progress.keys())
 


### PR DESCRIPTION
## Summary
- ensure wipe progress files exist when loading
- show species only from the selected wipe
- auto-create rule entries when a new species is encountered
- refresh dropdowns when wipe changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e75989c8832188fb0db746ea1802