### PR TITLE
Add custom stat list lines

### DIFF
--- a/stat_list.py
+++ b/stat_list.py
@@ -7,7 +7,6 @@ from typing import List
 from progress_tracker import load_progress
 
 PROGRESS_FILE = "breeding_progress.json"  # unused but kept for compatibility
-EXTRA_TAMES_FILE = "extra_tames.json"
 RULES_FILE = "rules.json"
 SETTINGS_FILE = "settings.json"
 OUTPUT_FILE = "stat_list.txt"
@@ -35,12 +34,6 @@ def get_mode(settings):
     save_settings(settings)
     return mode
 
-def merge_extra(progress):
-    extra = load_json(EXTRA_TAMES_FILE)
-    for sp, data in extra.items():
-        if sp not in progress:
-            progress[sp] = data
-    return progress
 
 def format_full(stud, thresh):
     tokens = []
@@ -75,7 +68,6 @@ def format_mutation(stud, thresh, mutation_stats):
 
 def generate_stat_list(progress, rules, settings) -> List[str]:
     """Return formatted stat list lines based on progress and rules."""
-    progress = merge_extra(progress)
     mode = settings.get("stat_list_mode", "full")
 
     lines: List[str] = []
@@ -94,6 +86,10 @@ def generate_stat_list(progress, rules, settings) -> List[str]:
 
         if tokens:
             lines.append(f"{' '.join(tokens)} {species}")
+
+    extra = settings.get("custom_stat_list_lines", [])
+    if isinstance(extra, list):
+        lines.extend(extra)
 
     return lines
 

--- a/tests/test_stat_list.py
+++ b/tests/test_stat_list.py
@@ -1,8 +1,7 @@
 import stat_list
 
 
-def test_generate_stat_list_full(monkeypatch):
-    monkeypatch.setattr(stat_list, "load_json", lambda p: {})
+def test_generate_stat_list_full():
     progress = {
         "Dodo": {"stud": {"health": 10}, "mutation_thresholds": {"health": 1}}
     }
@@ -11,8 +10,7 @@ def test_generate_stat_list_full(monkeypatch):
     assert lines == ["10+1H Dodo"]
 
 
-def test_generate_stat_list_mutation(monkeypatch):
-    monkeypatch.setattr(stat_list, "load_json", lambda p: {})
+def test_generate_stat_list_mutation():
     progress = {
         "Dodo": {
             "stud": {"health": 10, "melee": 5},
@@ -25,8 +23,7 @@ def test_generate_stat_list_mutation(monkeypatch):
     assert lines == ["5+2M Dodo"]
 
 
-def test_generate_stat_list_mutation_fallback(monkeypatch):
-    monkeypatch.setattr(stat_list, "load_json", lambda p: {})
+def test_generate_stat_list_mutation_fallback():
     progress = {
         "Dodo": {"stud": {"health": 10}, "mutation_thresholds": {"health": 1}}
     }


### PR DESCRIPTION
## Summary
- remove use of extra_tames.json
- append optional `custom_stat_list_lines` from settings
- allow adding or removing custom lines in progress tab
- adjust stat list tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e75f001c8321be7bc66f75afa88d