### PR TITLE
Handle wipe-specific progress initialization

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -27,6 +27,7 @@ from tabs.tools_tab import build_tools_tab
 from tabs.script_control_tab import build_test_tab
 from tabs.progress_tab import build_progress_tab
 from utils.config_validator import validate_configs
+from utils.helpers import refresh_species_dropdown
 
 SETTINGS_FILE = "settings.json"
 RULES_FILE = "rules.json"
@@ -264,6 +265,13 @@ class SettingsEditor(tk.Tk):
                     normalized, self.settings.get("default_species_template", {})
                 )
                 progress = load_progress(self.settings.get("current_wipe", "default"))
+                new_species = False
+                if normalized not in progress:
+                    new_species = True
+                    if normalized not in self.rules:
+                        self.rules[normalized] = deepcopy(self.settings.get("default_species_template", {}))
+                        with open(RULES_FILE, "w", encoding="utf-8") as f:
+                            json.dump(self.rules, f, indent=2)
 
                 # Step 1: update top‐stats
                 updated_stats = update_top_stats(egg, stats, progress)
@@ -321,6 +329,8 @@ class SettingsEditor(tk.Tk):
                     "updated_mutation_stud": updated_mstud
                 })
                 save_progress(progress, self.settings.get("current_wipe", "default"))
+                if new_species:
+                    refresh_species_dropdown(self)
                 # print UI feedback
                 self.log_message(f"→ {egg}: {decision.upper()}")
                 for k, v in reasons.items():

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -53,8 +53,13 @@ def load_progress(wipe: str = "default"):
     path = get_progress_file(wipe)
     ensure_wipe_dir(wipe)
     if os.path.exists(path):
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({}, f)
+            return {}
     return {}
 
 def save_progress(data, wipe: str = "default"):

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -1,10 +1,10 @@
 import tkinter as tk
 from tkinter import ttk
 from utils.dialogs import show_info
-from progress_tracker import ensure_wipe_dir
+from progress_tracker import ensure_wipe_dir, load_progress
 import os
 
-from utils.helpers import add_tooltip
+from utils.helpers import add_tooltip, refresh_species_dropdown
 
 FONT = ("Segoe UI", 10)
 
@@ -95,6 +95,8 @@ def build_global_tab(app):
         app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
         app.settings["current_wipe"] = app.wipe_var.get() or "default"
         ensure_wipe_dir(app.settings["current_wipe"])
+        app.progress = load_progress(app.settings["current_wipe"])
+        refresh_species_dropdown(app)
         with open("settings.json", "w", encoding="utf-8") as f:
             import json
             json.dump(app.settings, f, indent=2)

--- a/tabs/species_tab.py
+++ b/tabs/species_tab.py
@@ -21,7 +21,8 @@ def build_species_tab(app):
     # Track last-loaded species for autosave
     app._last_species = None
 
-    # populate dropdown from progress data so switching wipes updates correctly
+    # populate dropdown using only the current wipe's progress
+    app.progress = progress_tracker.load_progress(app.settings.get("current_wipe", "default"))
     app.species_list = sorted(app.progress.keys())
     app.species_dropdown = ttk.Combobox(
         app.tab_species,

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,9 +1,12 @@
 import tkinter as tk
 from tkinter import ttk
+from progress_tracker import load_progress
 
 
 def refresh_species_dropdown(app):
-    """Update the species combobox with keys from ``app.progress``."""
+    """Reload progress for the current wipe and refresh the dropdown."""
+    if hasattr(app, "settings"):
+        app.progress = load_progress(app.settings.get("current_wipe", "default"))
     if hasattr(app, "species_dropdown"):
         app.species_dropdown["values"] = sorted(app.progress.keys())
 


### PR DESCRIPTION
## Summary
- initialize progress files when empty
- refresh species dropdown on wipe changes
- create default rules when new species appear

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848625d6acc8321a216392d23af0b1d