### PR TITLE
Improve stud update logic

### DIFF
--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -181,6 +181,19 @@ def update_stud(egg, scan_stats, config, progress):
         }
         return True
 
+    if match_count == stud_count and match_count > 0:
+        for stat in merge_stats:
+            base = scan_stats.get(stat, {}).get("base", 0)
+            if base > stud.get(stat, 0):
+                log.info(
+                    f"New stud accepted for {s}; {stat} base {base}>{stud.get(stat, 0)}"
+                )
+                progress[s]["stud"] = {
+                    st: scan_stats.get(st, {}).get("base", 0)
+                    for st in merge_stats
+                }
+                return True
+
     return False
 
 def update_mutation_stud(egg, scan_stats, config, progress):

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -84,3 +84,21 @@ def test_update_mutation_stud_updates_value():
         updated = progress_tracker.update_mutation_stud('egg', stats, config, progress)
     assert updated is True
     assert progress['Rex']['mutation_stud']['melee'] == 6
+
+
+def test_update_stud_equal_match_better_base():
+    progress = {
+        'Rex': {
+            'top_stats': {'melee': 5},
+            'stud': {'melee': 5},
+            'mutation_thresholds': {},
+            'mutation_stud': {},
+            'female_count': 0
+        }
+    }
+    config = {'stat_merge_stats': ['melee']}
+    stats = {'melee': {'base': 6}}
+    with patch('progress_tracker.normalize_species_name', return_value='Rex'), patch('progress_tracker.log'):
+        updated = progress_tracker.update_stud('egg', stats, config, progress)
+    assert updated is True
+    assert progress['Rex']['stud']['melee'] == 6


### PR DESCRIPTION
## Summary
- improve `update_stud` logic to also handle equal match counts
- add a unit test for base-value improvements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684873110b0483218a11209f5e5caa83