### PR TITLE
Refactor automated mode handling

### DIFF
--- a/breeding_logic.py
+++ b/breeding_logic.py
@@ -3,7 +3,7 @@ log = get_logger("breeding_logic")
 kept_log = get_logger("kept_eggs")
 destroyed_log = get_logger("destroyed_eggs")
 
-from progress_tracker import normalize_species_name
+from progress_tracker import normalize_species_name, apply_automated_modes
 
 def should_keep_egg(scan, rules, progress):
     egg = scan["egg"]
@@ -33,18 +33,8 @@ def should_keep_egg(scan, rules, progress):
 
     # determine effective modes, accounting for automated logic
     enabled = set(rules.get("modes", []))
-    if "automated" in enabled:
-        count = progress.get(species, {}).get("female_count", 0)
-        if count < 30:
-            enabled.update({"mutations", "stat_merge", "all_females"})
-            enabled.discard("top_stat_females")
-        elif count < 96:
-            enabled.update({"mutations", "stat_merge", "top_stat_females"})
-            enabled.discard("all_females")
-        else:
-            enabled.update({"mutations", "stat_merge"})
-            enabled.discard("all_females")
-            enabled.discard("top_stat_females")
+    count = progress.get(species, {}).get("female_count", 0)
+    enabled = apply_automated_modes(count, enabled)
 
     # ─── AUTO-DESTROY FEMALES WHEN NO FEMALE-MODES ENABLED ────────
     female_modes = {"all_females", "top_stat_females", "war"}

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -217,6 +217,23 @@ def increment_female_count(egg, progress, sex):
     log.info(f"Female count for {s} is now {progress[s]['female_count']}")
     return progress[s]["female_count"]
 
+def apply_automated_modes(female_count, modes):
+    """Return a new set of modes after applying automated rules."""
+    modes = set(modes)
+    if "automated" in modes:
+        if female_count < 30:
+            modes.update({"mutations", "stat_merge", "all_females"})
+            modes.discard("top_stat_females")
+        elif female_count < 96:
+            modes.update({"mutations", "stat_merge", "top_stat_females"})
+            modes.discard("all_females")
+        else:
+            modes.update({"mutations", "stat_merge"})
+            modes.discard("all_females")
+            modes.discard("top_stat_females")
+            modes.discard("automated")
+    return modes
+
 def adjust_rules_for_females(species, progress, rules, default_template=None):
     """Adjust breeding rules based on female counts."""
     if species not in rules:
@@ -233,18 +250,7 @@ def adjust_rules_for_females(species, progress, rules, default_template=None):
     modes = set(rules[species].get("modes", []))
     before = modes.copy()
 
-    if "automated" in modes:
-        if count < 30:
-            modes.update({"mutations", "stat_merge", "all_females"})
-            modes.discard("top_stat_females")
-        elif count < 96:
-            modes.update({"mutations", "stat_merge", "top_stat_females"})
-            modes.discard("all_females")
-        else:
-            modes.update({"mutations", "stat_merge"})
-            modes.discard("all_females")
-            modes.discard("top_stat_females")
-            modes.discard("automated")
+    modes = apply_automated_modes(count, modes)
 
     if modes != before:
         rules[species]["modes"] = list(modes)

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -84,3 +84,18 @@ def test_update_mutation_stud_updates_value():
         updated = progress_tracker.update_mutation_stud('egg', stats, config, progress)
     assert updated is True
     assert progress['Rex']['mutation_stud']['melee'] == 6
+
+
+def test_apply_automated_modes_low_count():
+    result = progress_tracker.apply_automated_modes(10, {'automated'})
+    assert result == {'automated', 'mutations', 'stat_merge', 'all_females'}
+
+
+def test_apply_automated_modes_mid_count():
+    result = progress_tracker.apply_automated_modes(50, {'automated', 'all_females'})
+    assert result == {'automated', 'mutations', 'stat_merge', 'top_stat_females'}
+
+
+def test_apply_automated_modes_high_count():
+    result = progress_tracker.apply_automated_modes(150, {'automated', 'all_females', 'top_stat_females'})
+    assert result == {'mutations', 'stat_merge'}


### PR DESCRIPTION
## Summary
- centralize automated-mode adjustments in `apply_automated_modes`
- reuse helper in `breeding_logic` and `adjust_rules_for_females`
- test helper to ensure same behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684872effaac83219e58af01ede93b05