### PR TITLE
Fix scanner validation for zero-stat dinos

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -173,10 +173,11 @@ def scan_once(settings, debug=False):
     return {"species": species, "stats": stats}
 
 def is_invalid(scan):
-    # ignore zero oxygen (legit for some species)
-    zeros = sum(1 for stat,v in scan["stats"].items() if stat!="oxygen" and v["base"]==0)
+    """Return True when OCR produced obviously bogus values."""
+    # Values of 0 are legitimate, so we only guard against excessively
+    # large numbers which indicate an OCR failure.
     too_big = any(v["base"] > 99 for v in scan["stats"].values())
-    return zeros > 1 or too_big
+    return too_big
 
 def scan_slot(settings, debug=False):
     """OCR a single slot with validation and optional re-scans."""

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,24 @@
+import sys
+import types
+
+# Provide dummy pyautogui so scanner can import without a display
+sys.modules['pyautogui'] = types.SimpleNamespace(onScreen=lambda *a, **k: False)
+
+import scanner
+
+
+def test_is_invalid_all_zero_stats():
+    scan = {
+        "species": "CS Test Male",
+        "stats": {
+            "health": {"base": 0},
+            "stamina": {"base": 0},
+            "oxygen": {"base": 0},
+            "food": {"base": 0},
+            "weight": {"base": 0},
+            "melee": {"base": 0},
+            "speed": {"base": 0},
+        },
+    }
+    assert scanner.is_invalid(scan) is False
+


### PR DESCRIPTION
## Summary
- allow zero values in scanner validation
- add a test that imports `scanner.is_invalid` without needing a display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489f9b86688321b895bcdbd2d76e7c