### PR TITLE
Add wipe-aware history tracking

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -264,7 +264,8 @@ class SettingsEditor(tk.Tk):
                 config = self.rules.get(
                     normalized, self.settings.get("default_species_template", {})
                 )
-                progress = load_progress(self.settings.get("current_wipe", "default"))
+                wipe = self.settings.get("current_wipe", "default")
+                progress = load_progress(wipe)
                 new_species = False
                 if normalized not in progress:
                     new_species = True
@@ -274,7 +275,7 @@ class SettingsEditor(tk.Tk):
                             json.dump(self.rules, f, indent=2)
 
                 # Step 1: update top‐stats
-                updated_stats = update_top_stats(egg, stats, progress)
+                updated_stats = update_top_stats(egg, stats, progress, wipe)
 
                 # Step 2: decide keep/destroy
                 decision, reasons = should_keep_egg(
@@ -294,7 +295,7 @@ class SettingsEditor(tk.Tk):
                 # Step 3: update thresholds only if mutations rule passed
                 if reasons.get("mutations"):
                     updated_thresholds = update_mutation_thresholds(
-                        egg, stats, config, progress, sex
+                        egg, stats, config, progress, sex, wipe
                     )
                 else:
                     updated_thresholds = False
@@ -328,7 +329,7 @@ class SettingsEditor(tk.Tk):
                     "updated_stud": updated_stud,
                     "updated_mutation_stud": updated_mstud
                 })
-                save_progress(progress, self.settings.get("current_wipe", "default"))
+                save_progress(progress, wipe)
                 if new_species:
                     refresh_species_dropdown(self)
                 # print UI feedback

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -82,12 +82,12 @@ def save_history(hist, wipe: str = "default"):
     with open(path, "w", encoding="utf-8") as f:
         json.dump(hist, f, indent=2)
 
-def record_history(species: str, category: str, stat: str, value: int) -> None:
-    hist = load_history()
+def record_history(species: str, category: str, stat: str, value: int, wipe: str = "default") -> None:
+    hist = load_history(wipe)
     species_hist = hist.setdefault(species, {"top_stats": {}, "mutation_thresholds": {}})
     cat_hist = species_hist.setdefault(category, {}).setdefault(stat, [])
     cat_hist.append({"ts": int(time.time()), "value": value})
-    save_history(hist)
+    save_history(hist, wipe)
 
 def normalize_species_name(raw_name):
     """
@@ -114,7 +114,7 @@ def normalize_species_name(raw_name):
 
     return cleaned
 
-def update_top_stats(egg, scan_stats, progress):
+def update_top_stats(egg, scan_stats, progress, wipe: str = "default"):
     s = normalize_species_name(egg)
     updated = False
     log.debug(f"Evaluating top stats for {s}")
@@ -128,12 +128,12 @@ def update_top_stats(egg, scan_stats, progress):
         if base > current:
             log.info(f"New top stat for {stat}: {base} (was {current})")
             progress[s]["top_stats"][stat] = base
-            record_history(s, "top_stats", stat, base)
+            record_history(s, "top_stats", stat, base, wipe)
             updated = True
 
     return updated
 
-def update_mutation_thresholds(egg, scan_stats, config, progress, sex):
+def update_mutation_thresholds(egg, scan_stats, config, progress, sex, wipe: str = "default"):
     if sex != "male":
         return False
     s = normalize_species_name(egg)
@@ -150,7 +150,7 @@ def update_mutation_thresholds(egg, scan_stats, config, progress, sex):
         if mut > current:
             log.info(f"New threshold for {stat}: {mut} (was {current})")
             progress[s]["mutation_thresholds"][stat] = mut
-            record_history(s, "mutation_thresholds", stat, mut)
+            record_history(s, "mutation_thresholds", stat, mut, wipe)
             updated = True
 
     return updated

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -75,10 +75,11 @@ def test_scan_egg(app):
     normalized = normalize_species_name(egg)
 
     config = app.rules.get(normalized, app.settings.get("default_species_template", {}))
-    progress = load_progress(app.settings.get("current_wipe", "default"))
+    wipe = app.settings.get("current_wipe", "default")
+    progress = load_progress(wipe)
 
-    update_top_stats(egg, stats, progress)
-    update_mutation_thresholds(egg, stats, config, progress, sex)
+    update_top_stats(egg, stats, progress, wipe)
+    update_mutation_thresholds(egg, stats, config, progress, sex, wipe)
     if sex == "male":
         update_stud(egg, stats, config, progress)
         update_mutation_stud(egg, stats, config, progress)
@@ -87,14 +88,14 @@ def test_scan_egg(app):
         "egg": egg,
         "sex": sex,
         "stats": stats,
-        "updated_stats": update_top_stats(egg, stats, progress),
-        "updated_thresholds": update_mutation_thresholds(egg, stats, config, progress, sex),
+        "updated_stats": update_top_stats(egg, stats, progress, wipe),
+        "updated_thresholds": update_mutation_thresholds(egg, stats, config, progress, sex, wipe),
         "updated_stud": update_stud(egg, stats, config, progress) if sex == "male" else False,
         "updated_mutation_stud": update_mutation_stud(egg, stats, config, progress) if sex == "male" else False
     })
 
     decision, reasons = should_keep_egg(scan, config, progress)
-    save_progress(progress, app.settings.get("current_wipe", "default"))
+    save_progress(progress, wipe)
 
     print(f"→ Scanned Egg: {egg} | DECISION: {decision.upper()}")
     for k, v in reasons.items():


### PR DESCRIPTION
## Summary
- add `wipe` parameter to `record_history` and hook up wipe-aware load/save
- propagate wipe support through `update_top_stats` and `update_mutation_thresholds`
- update GUI logic to pass the selected wipe
- adjust script control test tab for wipe aware stats
- extend tests for new arguments and verify custom wipe history path

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c29e35988321bd07eb51cfe357cf