### PR TITLE
Adjust automated breeding threshold

### DIFF
--- a/docs/automated_mode.md
+++ b/docs/automated_mode.md
@@ -28,7 +28,7 @@ Relevant excerpt from `adjust_rules_for_females`:
 
 ```python
 if "automated" in modes:
-    if count < 30:
+    if count < 15:
         modes.update({"mutations", "stat_merge", "all_females"})
         modes.discard("top_stat_females")
     elif count < 96:

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -237,7 +237,7 @@ def apply_automated_modes(female_count, modes):
     if "automated" not in modes:
         return modes
 
-    if female_count < 30:
+    if female_count < 15:
         modes.update({"mutations", "stat_merge", "all_females"})
         modes.discard("top_stat_females")
     elif female_count < 96:

--- a/tests/test_breeding_logic.py
+++ b/tests/test_breeding_logic.py
@@ -123,7 +123,7 @@ class ShouldKeepEggTests(TestCase):
         self.assertEqual(decision, "rescan")
         self.assertEqual(res["_debug"]["final"], "rescan")
 
-    def test_automated_all_females_under_30(self):
+    def test_automated_all_females_under_15(self):
         scan = {"egg": "CS Test Female", "sex": "female", "stats": {}}
         rules = {"modes": ["automated"]}
         progress = {"TestDino": {"female_count": 10}}


### PR DESCRIPTION
## Summary
- shrink the automated breeding threshold from 30 females to 15
- document new limit in the automation overview
- update unit test naming for clarity

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ce987e2883218a582b819ba0f7c7