### PR TITLE
Fix default rules for new species

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -269,10 +269,16 @@ class SettingsEditor(tk.Tk):
                 new_species = False
                 if normalized not in progress:
                     new_species = True
-                    if normalized not in self.rules:
-                        self.rules[normalized] = deepcopy(self.settings.get("default_species_template", {}))
-                        with open(RULES_FILE, "w", encoding="utf-8") as f:
-                            json.dump(self.rules, f, indent=2)
+                    # initialize rules entry from the default template and
+                    # ensure automated mode is always enabled
+                    template = deepcopy(self.settings.get("default_species_template", {}))
+                    modes = set(template.get("modes", []))
+                    modes.add("automated")
+                    template["modes"] = list(modes)
+                    self.rules[normalized] = template
+                    config = self.rules[normalized]
+                    with open(RULES_FILE, "w", encoding="utf-8") as f:
+                        json.dump(self.rules, f, indent=2)
 
                 # Step 1: update top‐stats
                 updated_stats = update_top_stats(egg, stats, progress, wipe)


### PR DESCRIPTION
## Summary
- ensure automated is always enabled in default species template
- when a species is new to the progress, overwrite its rule using the default template and save `rules.json`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d0aadd60832191ff27990ca0f88a