### PR TITLE
Add Discord bot integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ pytest
 - **`dump_structure.py`** – Writes a text representation of the repository tree for debugging.
 
 Other modules implement breeding logic and progress tracking used by these scripts.
+
+## Discord Bot
+
+`discord_bot.py` implements a small Discord bot that can control the game and report breeding progress. Set your bot token in `settings.json` under the `bot_token` key or provide it via the `DISCORD_BOT_TOKEN` environment variable. Start the bot with:
+
+```bash
+python discord_bot.py
+```
+
+Once running you can use commands like `!dropall`, `!eatfood`, and `!progress <species>` in your Discord channel. The Progress tab will also use this token when sending summaries.

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -3,12 +3,14 @@ import json
 import time
 import asyncio
 import threading
+import urllib.request
 
 import discord
 from discord.ext import commands
 import pyautogui
 
 from auto_eat import eat_food
+from progress_tracker import load_progress
 
 SETTINGS_FILE = "settings.json"
 
@@ -19,10 +21,39 @@ BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN") or SETTINGS.get("bot_token")
 if not BOT_TOKEN:
     raise RuntimeError("Bot token not provided via DISCORD_BOT_TOKEN or settings.json")
 
+CHANNEL_ID = os.getenv("DISCORD_CHANNEL_ID")
+
 bot = commands.Bot(command_prefix="!")
 
 # shared lock to prevent simultaneous pyautogui actions
 GUI_LOCK = threading.Lock()
+
+
+def build_progress_message(species: str) -> str:
+    """Return a formatted breeding progress summary for ``species``."""
+    prog = load_progress(SETTINGS.get("current_wipe", "default")).get(species, {})
+    lines = [f"{species} stats:"]
+    lines.append(f"Females: {prog.get('female_count', 0)}")
+    lines.append("Top Stats:")
+    for st, val in prog.get("top_stats", {}).items():
+        lines.append(f"  {st}: {val}")
+    lines.append("Mutation Thresholds:")
+    for st, val in prog.get("mutation_thresholds", {}).items():
+        lines.append(f"  {st}: {val}")
+    return "\n".join(lines)
+
+
+def send_progress_message(message: str) -> None:
+    """Send ``message`` to the configured Discord channel using the bot token."""
+    if not CHANNEL_ID:
+        raise RuntimeError("DISCORD_CHANNEL_ID not set")
+    url = f"https://discord.com/api/v10/channels/{CHANNEL_ID}/messages"
+    headers = {
+        "Authorization": f"Bot {BOT_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    req = urllib.request.Request(url, data=json.dumps({"content": message}).encode("utf-8"), headers=headers)
+    urllib.request.urlopen(req)
 
 
 def drop_all(settings):
@@ -55,6 +86,13 @@ async def eatfood(ctx):
     with GUI_LOCK:
         eat_food(SETTINGS)
     await ctx.send("🍗 Ate one food item")
+
+
+@bot.command()
+async def progress(ctx, *, species: str):
+    """Send breeding progress summary for ``species``."""
+    msg = build_progress_message(species)
+    await ctx.send(msg)
 
 
 bot.run(BOT_TOKEN)

--- a/settings.json
+++ b/settings.json
@@ -14,6 +14,7 @@
   "hotkey_scan": "F8",
   "auto_eat_enabled": false,
   "webhook_url": "",
+  "bot_token": "",
   "debug_mode": false,
   "drop_all_button": [
     495,

--- a/tabs/progress_tab.py
+++ b/tabs/progress_tab.py
@@ -95,17 +95,12 @@ def build_progress_tab(app):
         msg = "\n".join(lines)
         app.clipboard_clear()
         app.clipboard_append(msg)
-        url = app.settings.get("webhook_url", "")
-        if url:
-            try:
-                import urllib.request
-                req = urllib.request.Request(url, data=json.dumps({"content": msg}).encode("utf-8"), headers={"Content-Type": "application/json"})
-                urllib.request.urlopen(req)
-                show_info("Sent", "Summary sent to Discord and copied to clipboard.")
-            except Exception as e:
-                show_error("Error", str(e))
-        else:
-            show_info("Copied", "Summary copied to clipboard.")
+        try:
+            from discord_bot import send_progress_message
+            send_progress_message(msg)
+            show_info("Sent", "Summary sent to Discord and copied to clipboard.")
+        except Exception as e:
+            show_error("Error", str(e))
 
     btn_frame = ttk.Frame(app.tab_progress)
     btn_frame.grid(row=row, column=0, columnspan=3, padx=5, pady=5, sticky="w")

--- a/utils/config_validator.py
+++ b/utils/config_validator.py
@@ -22,6 +22,7 @@ def validate_settings(settings: Dict[str, Any]) -> List[str]:
         "hotkey_scan": str,
         "debug_mode": (bool, dict),
         "webhook_url": str,
+        "bot_token": str,
         "drop_all_button": list,
         "drop_all_confirm": list,
         "food_slots": list,


### PR DESCRIPTION
## Summary
- store new `bot_token` setting
- validate `bot_token` in config validator
- allow Progress tab to send via the Discord bot
- implement progress command and helpers in `discord_bot.py`
- document running the Discord bot

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cffc93c4832180f9fc50aadb7175