### PR TITLE
Improve log behavior on debug toggle

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -10,6 +10,9 @@ except FileNotFoundError:
 
 debug_flags = cfg.get("debug_mode", False)
 
+# Default to WARNING so only important events show when debug flags are off
+logging.getLogger().setLevel(logging.WARNING)
+
 def get_logger(module_name: str) -> logging.Logger:
     # if debug_flags is a dict, look up per-module;
     # if it's a bool, apply it to everything.

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -45,6 +45,7 @@ def ensure_species(progress, species):
     """Ensure a species entry exists with all required keys."""
     if species not in progress:
         progress[species] = deepcopy(DEFAULT_PROGRESS_TEMPLATE)
+        log.info(f"Added new species to progress: {species}")
     else:
         for k, v in DEFAULT_PROGRESS_TEMPLATE.items():
             progress[species].setdefault(k, v if isinstance(v, dict) else 0)

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -100,6 +100,16 @@ def build_global_tab(app):
         with open("settings.json", "w", encoding="utf-8") as f:
             import json
             json.dump(app.settings, f, indent=2)
+        try:
+            import importlib, logger, scanner, breeding_logic, progress_tracker
+            importlib.reload(logger)
+            scanner.log = logger.get_logger("scanner")
+            breeding_logic.log = logger.get_logger("breeding_logic")
+            breeding_logic.kept_log = logger.get_logger("kept_eggs")
+            breeding_logic.destroyed_log = logger.get_logger("destroyed_eggs")
+            progress_tracker.log = logger.get_logger("progress_tracker")
+        except Exception:
+            pass
         show_info("Saved", "Global settings saved.")
         if hasattr(app, "update_hotkeys"):
             app.update_hotkeys()


### PR DESCRIPTION
## Summary
- default root logger to WARNING so info messages stand out
- log when a new species entry is created
- reload module loggers when saving global settings

## Testing
- `pip install opencv-python-headless pytesseract -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d47e1cc8832195496a9cee808d8e