### PR TITLE
Update layout and wipe handling

### DIFF
--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -25,6 +25,16 @@ def build_global_tab(app):
     )
     wipe_combo.grid(row=row, column=1, sticky="w", padx=5, pady=2)
     add_tooltip(wipe_combo, "Select or enter wipe name")
+
+    def on_wipe_change(_=None):
+        app.settings["current_wipe"] = app.wipe_var.get() or "default"
+        ensure_wipe_dir(app.settings["current_wipe"])
+        app.progress = load_progress(app.settings["current_wipe"])
+        refresh_species_dropdown(app)
+
+    wipe_combo.bind("<<ComboboxSelected>>", on_wipe_change)
+    wipe_combo.bind("<Return>", on_wipe_change)
+    wipe_combo.bind("<FocusOut>", on_wipe_change)
     row += 1
     ttk.Label(app.tab_global, text="Hotkey Scan", font=FONT).grid(
         row=row, column=0, sticky="w", padx=5, pady=2
@@ -62,7 +72,7 @@ def build_global_tab(app):
 
     app.auto_eat_var = tk.BooleanVar(value=app.settings.get("auto_eat_enabled", False))
     cb_auto = ttk.Checkbutton(app.tab_global, text="Enable Auto-Eat", variable=app.auto_eat_var)
-    cb_auto.grid(row=row, column=0, columnspan=2, sticky="w", padx=5, pady=2)
+    cb_auto.grid(row=row, column=2, sticky="w", padx=5, pady=2)
     add_tooltip(cb_auto, "Automatically consume food periodically")
     row += 1
 
@@ -115,5 +125,5 @@ def build_global_tab(app):
             app.update_hotkeys()
 
     ttk.Button(app.tab_global, text="Save Settings", command=save_all).grid(
-        row=row, column=0, columnspan=2, pady=10
+        row=row, column=0, columnspan=3, pady=10
     )

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -4,11 +4,14 @@ from progress_tracker import load_progress
 
 
 def refresh_species_dropdown(app):
-    """Reload progress for the current wipe and refresh the dropdown."""
+    """Reload progress for the current wipe and refresh all species dropdowns."""
     if hasattr(app, "settings"):
         app.progress = load_progress(app.settings.get("current_wipe", "default"))
+    species = sorted(app.progress.keys())
     if hasattr(app, "species_dropdown"):
-        app.species_dropdown["values"] = sorted(app.progress.keys())
+        app.species_dropdown["values"] = species
+    if hasattr(app, "progress_dropdown"):
+        app.progress_dropdown["values"] = species
 
 
 def add_tooltip(widget, text: str) -> None:


### PR DESCRIPTION
## Summary
- keep progress dropdown in sync with current wipe
- move auto-eat checkbox to its own column
- trigger dropdown refresh when wipe changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e0998d0483219d4a44f693975abc