### PR TITLE
Implement breeding automation sub-tab

### DIFF
--- a/breeding_logic.py
+++ b/breeding_logic.py
@@ -33,6 +33,8 @@ def should_keep_egg(scan, rules, progress):
 
     # determine effective modes, accounting for automated logic
     enabled = set(rules.get("modes", []))
+    # mutations and stat_merge are always active
+    enabled.update({"mutations", "stat_merge"})
     count = progress.get(species, {}).get("female_count", 0)
     enabled = apply_automated_modes(count, enabled)
 

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -21,6 +21,8 @@ DEFAULT_PROGRESS_TEMPLATE = {
     "stud": {},
     "mutation_stud": {},
     "female_count": 0,
+    "stop_female_count": 0,
+    "stop_top_stat_females": 0,
 }
 
 def get_progress_file(wipe: str = "default") -> str:


### PR DESCRIPTION
## Summary
- add stop counters to breeding progress tracking
- make `mutations` and `stat_merge` always active in breeding logic
- rework species config UI with a new "Auto" sub-tab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e644aa2c8321920aeac644f5bc93