### PR TITLE
Adjust Defaults tab and calibration control

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -166,7 +166,7 @@ class SettingsEditor(tk.Tk):
         self.tab_species = ttk.Frame(tabs)
         tabs.add(self.tab_species, text="Species Config")
         self.tab_tools = ttk.Frame(tabs)
-        tabs.add(self.tab_tools, text="Defaults & Tools")
+        tabs.add(self.tab_tools, text="Defaults")
         self.tab_progress = ttk.Frame(tabs)
         tabs.add(self.tab_progress, text="Progress")
         self.tab_help = ttk.Frame(tabs)

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -3,6 +3,8 @@ from tkinter import ttk, scrolledtext
 import time
 from scanner import scan_slot
 from utils.helpers import add_tooltip
+from utils.calibration import run_calibration as calibration_wizard
+from utils.dialogs import show_error
 
 FONT = ("Segoe UI", 10)
 
@@ -52,6 +54,10 @@ def build_test_tab(app):
     btn_clear = ttk.Button(app.tab_test, text="Clear Log", command=lambda: clear_log(app))
     btn_clear.pack(pady=(0, 10))
     add_tooltip(btn_clear, "Erase all entries from the log viewer")
+
+    btn_cal = ttk.Button(app.tab_test, text="Run Calibration", command=run_calibration)
+    btn_cal.pack(pady=(0, 10))
+    add_tooltip(btn_cal, "Launch the calibration tool to record screen positions")
 
     ttk.Label(app.tab_test, text="Testing Utilities", font=(FONT[0], FONT[1], "bold")).pack(pady=(20, 2))
     btn = ttk.Button(app.tab_test, text="Force KEEP (Real Logic)", command=app.keep_egg)
@@ -121,4 +127,11 @@ def clear_log(app):
         app.log_widget.configure(state="normal")
         app.log_widget.delete("1.0", "end")
         app.log_widget.configure(state="disabled")
+
+def run_calibration():
+    """Launch the calibration wizard inside the application."""
+    try:
+        calibration_wizard()
+    except Exception as e:
+        show_error("Error", str(e))
 

--- a/tabs/tools_tab.py
+++ b/tabs/tools_tab.py
@@ -1,10 +1,8 @@
 import tkinter as tk
 from tkinter import ttk
-from utils.dialogs import show_error, show_warning, show_info
+from utils.dialogs import show_info
 import json
-from utils.calibration import run_calibration as calibration_wizard
-from utils.helpers import refresh_species_dropdown, add_tooltip
-from copy import deepcopy
+from utils.helpers import add_tooltip
 
 FONT = ("Segoe UI", 10)
 
@@ -13,20 +11,6 @@ DEFAULT_MODES = ["mutations", "all_females", "stat_merge", "top_stat_females", "
 
 def build_tools_tab(app):
     row = 0
-    btn = ttk.Button(app.tab_tools, text="Run Calibration", command=run_calibration)
-    btn.grid(row=row, column=0, sticky="w", padx=5, pady=2)
-    add_tooltip(btn, "Launch the calibration tool to record screen positions")
-    row += 1
-
-    btn = ttk.Button(app.tab_tools, text="Refresh from Progress", command=lambda: refresh_species(app))
-    btn.grid(row=row, column=0, sticky="w", padx=5, pady=2)
-    add_tooltip(btn, "Generate rules from breeding_progress.json data")
-    row += 1
-
-    btn = ttk.Button(app.tab_tools, text="Save All Settings", command=lambda: save_all(app))
-    btn.grid(row=row, column=0, sticky="w", padx=5, pady=2)
-    add_tooltip(btn, "Save settings.json and rules.json")
-    row += 2
 
     ttk.Label(app.tab_tools, text="Default Settings for New Species:", font=("Segoe UI", 10, "bold")).grid(
         row=row, column=0, sticky="w", padx=5, pady=2
@@ -67,11 +51,6 @@ def build_tools_tab(app):
         stat: tk.BooleanVar(value=(stat in shared_defaults))
         for stat in ALL_STATS
     }
-    mutation_defaults = set(template.get("mutation_stats", ALL_STATS))
-    app.default_mutation_vars = {
-        stat: tk.BooleanVar(value=(stat in mutation_defaults))
-        for stat in ALL_STATS
-    }
 
     ttk.Label(app.tab_tools, text="Shared Stats (merge/top/war):", font=FONT).grid(
         row=row, column=0, sticky="w", padx=5, pady=(10, 2)
@@ -85,58 +64,16 @@ def build_tools_tab(app):
         add_tooltip(cb, f"Include {stat} for new species by default")
     row += 1
 
-    ttk.Label(app.tab_tools, text="Mutation Stats:", font=FONT).grid(
-        row=row, column=0, sticky="w", padx=5, pady=(10, 2)
-    )
-    row += 1
-    mf = ttk.Frame(app.tab_tools)
-    mf.grid(row=row, column=0, columnspan=3, sticky="w")
-    for i, stat in enumerate(ALL_STATS):
-        cb = ttk.Checkbutton(mf, text=stat, variable=app.default_mutation_vars[stat])
-        cb.grid(row=i//3, column=i%3, sticky="w", padx=10, pady=2)
-        add_tooltip(cb, f"Watch {stat} mutations for new species")
-    row += 1
+
 
     btn = ttk.Button(app.tab_tools, text="Apply These Defaults to New Species", command=lambda: set_defaults(app))
     btn.grid(row=row, column=0, pady=10)
     add_tooltip(btn, "Persist these defaults for future species")
 
-def run_calibration():
-    """Launch the calibration wizard inside the application."""
-    try:
-        calibration_wizard()
-    except Exception as e:
-        show_error("Error", str(e))
-
-def refresh_species(app):
-    from progress_tracker import load_progress
-    progress = load_progress(app.settings.get("current_wipe", "default"))
-    new_added = 0
-    default = app.settings.get("default_species_template", {})
-    for species in progress:
-        if species not in app.rules:
-            app.rules[species] = deepcopy(default)
-            new_added += 1
-    with open("rules.json", "w", encoding="utf-8") as f:
-        json.dump(app.rules, f, indent=2)
-    from utils.helpers import refresh_species_dropdown
-    refresh_species_dropdown(app)
-    show_info("Refreshed", f"Added {new_added} new species.")
-
-def save_all(app):
-    app.settings["hotkey_scan"] = app.hotkey_var.get()
-    app.settings["popup_delay"] = app.popup_delay_var.get()
-    app.settings["action_delay"] = app.action_delay_var.get()
-    app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
-    app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
-    with open("settings.json", "w", encoding="utf-8") as f:
-        json.dump(app.settings, f, indent=2)
-    show_info("Saved", "All settings saved.")
 
 def set_defaults(app):
     app.settings["default_species_template"] = {
         "modes": [mode for mode, var in app.default_mode_vars.items() if var.get()],
-        "mutation_stats": [stat for stat, var in app.default_mutation_vars.items() if var.get()],
         "stat_merge_stats": [stat for stat, var in app.default_stat_vars.items() if var.get()],
         "top_stat_females_stats": [stat for stat, var in app.default_stat_vars.items() if var.get()],
         "war_stats": [stat for stat, var in app.default_stat_vars.items() if var.get()]


### PR DESCRIPTION
## Summary
- rename the "Defaults & Tools" tab to "Defaults"
- trim options in the Defaults tab
- move the calibration launcher to the Script Control tab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ebbf570c8321925e7bfe7c08f6a2