### PR TITLE
Add GUI stat list tab

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -169,6 +169,8 @@ class SettingsEditor(tk.Tk):
         tabs.add(self.tab_tools, text="Defaults")
         self.tab_stats = ttk.Frame(tabs)
         tabs.add(self.tab_stats, text="Studs")
+        self.tab_stat_list = ttk.Frame(tabs)
+        tabs.add(self.tab_stat_list, text="Stat List")
         self.tab_help = ttk.Frame(tabs)
         tabs.add(self.tab_help, text="Help")
 
@@ -177,6 +179,8 @@ class SettingsEditor(tk.Tk):
         build_species_tab(self)
         build_tools_tab(self)
         build_stats_tab(self)
+        from tabs.stat_list_tab import build_stat_list_tab
+        build_stat_list_tab(self)
         from tabs.help_tab import build_help_tab
         build_help_tab(self)
 

--- a/tabs/progress_tab.py
+++ b/tabs/progress_tab.py
@@ -1,7 +1,6 @@
 import tkinter as tk
 from tkinter import ttk
 from utils.dialogs import show_error, show_warning, show_info
-import json
 from progress_tracker import load_progress
 
 FONT = ("Segoe UI", 10)
@@ -20,19 +19,6 @@ def build_stats_tab(app):
 
     app.stat_list_text = tk.Text(app.tab_stats, height=6, width=50, state="disabled")
     app.stat_list_text.grid(row=row, column=0, columnspan=3, padx=5, pady=5, sticky="nsew")
-    row += 1
-
-    ttk.Label(app.tab_stats, text="Add Custom Line:", font=FONT).grid(row=row, column=0, sticky="w", padx=5)
-    app.custom_line_var = tk.StringVar()
-    entry = ttk.Entry(app.tab_stats, textvariable=app.custom_line_var, width=30)
-    entry.grid(row=row, column=1, sticky="w")
-    ttk.Button(app.tab_stats, text="Add", command=lambda: add_custom_line()).grid(row=row, column=2, sticky="w")
-    row += 1
-
-    app.custom_lines_list = tk.Listbox(app.tab_stats, height=4, width=50)
-    app.custom_lines_list.grid(row=row, column=0, columnspan=3, padx=5, pady=2, sticky="nsew")
-    row += 1
-    ttk.Button(app.tab_stats, text="Delete Selected", command=lambda: delete_custom_line()).grid(row=row, column=0, sticky="w", padx=5)
     row += 1
 
     def refresh_tables(event=None):
@@ -59,33 +45,8 @@ def build_stats_tab(app):
         app.stat_list_text.insert("end", "\n".join(lines))
         app.stat_list_text.configure(state="disabled")
 
-        app.custom_lines_list.delete(0, "end")
-        for line in app.settings.get("custom_stat_list_lines", []):
-            app.custom_lines_list.insert("end", line)
 
     app.progress_dropdown.bind("<<ComboboxSelected>>", refresh_tables)
-
-    def add_custom_line():
-        line = app.custom_line_var.get().strip()
-        if not line:
-            return
-        app.settings.setdefault("custom_stat_list_lines", []).append(line)
-        with open("settings.json", "w", encoding="utf-8") as f:
-            json.dump(app.settings, f, indent=2)
-        app.custom_line_var.set("")
-        refresh_tables()
-
-    def delete_custom_line():
-        sel = app.custom_lines_list.curselection()
-        if not sel:
-            return
-        idx = sel[0]
-        lines = app.settings.get("custom_stat_list_lines", [])
-        if 0 <= idx < len(lines):
-            del lines[idx]
-            with open("settings.json", "w", encoding="utf-8") as f:
-                json.dump(app.settings, f, indent=2)
-        refresh_tables()
 
     def send_summary():
         sp = app.progress_species.get()

--- a/tabs/stat_list_tab.py
+++ b/tabs/stat_list_tab.py
@@ -1,0 +1,72 @@
+import json
+import os
+import tkinter as tk
+from tkinter import ttk
+
+from progress_tracker import load_progress
+from stat_list import generate_stat_list
+
+FONT = ("Segoe UI", 10)
+
+
+def build_stat_list_tab(app):
+    row = 0
+    app.stat_list_box = tk.Text(app.tab_stat_list, height=10, width=50, state="disabled")
+    app.stat_list_box.grid(row=row, column=0, columnspan=3, padx=5, pady=5, sticky="nsew")
+    row += 1
+
+    ttk.Button(app.tab_stat_list, text="Refresh", command=lambda: refresh_list()).grid(row=row, column=0, sticky="w", padx=5)
+    row += 1
+
+    ttk.Label(app.tab_stat_list, text="Add Custom Line:", font=FONT).grid(row=row, column=0, sticky="w", padx=5)
+    app.custom_line_var = tk.StringVar()
+    entry = ttk.Entry(app.tab_stat_list, textvariable=app.custom_line_var, width=30)
+    entry.grid(row=row, column=1, sticky="w")
+    ttk.Button(app.tab_stat_list, text="Add", command=lambda: add_custom_line()).grid(row=row, column=2, sticky="w")
+    row += 1
+
+    app.custom_lines_list = tk.Listbox(app.tab_stat_list, height=4, width=50)
+    app.custom_lines_list.grid(row=row, column=0, columnspan=3, padx=5, pady=2, sticky="nsew")
+    row += 1
+    ttk.Button(app.tab_stat_list, text="Delete Selected", command=lambda: delete_custom_line()).grid(row=row, column=0, sticky="w", padx=5)
+    row += 1
+
+    def refresh_list(event=None):
+        progress = load_progress(app.settings.get("current_wipe", "default"))
+        rules = {}
+        if app.settings.get("stat_list_mode") == "mutation" and os.path.exists("rules.json"):
+            with open("rules.json", "r", encoding="utf-8") as f:
+                rules = json.load(f)
+        lines = generate_stat_list(progress, rules, app.settings)
+        app.stat_list_box.configure(state="normal")
+        app.stat_list_box.delete("1.0", "end")
+        app.stat_list_box.insert("end", "\n".join(lines))
+        app.stat_list_box.configure(state="disabled")
+
+        app.custom_lines_list.delete(0, "end")
+        for line in app.settings.get("custom_stat_list_lines", []):
+            app.custom_lines_list.insert("end", line)
+
+    def add_custom_line():
+        line = app.custom_line_var.get().strip()
+        if not line:
+            return
+        app.settings.setdefault("custom_stat_list_lines", []).append(line)
+        with open("settings.json", "w", encoding="utf-8") as f:
+            json.dump(app.settings, f, indent=2)
+        app.custom_line_var.set("")
+        refresh_list()
+
+    def delete_custom_line():
+        sel = app.custom_lines_list.curselection()
+        if not sel:
+            return
+        idx = sel[0]
+        lines = app.settings.get("custom_stat_list_lines", [])
+        if 0 <= idx < len(lines):
+            del lines[idx]
+            with open("settings.json", "w", encoding="utf-8") as f:
+                json.dump(app.settings, f, indent=2)
+        refresh_list()
+
+    refresh_list()


### PR DESCRIPTION
## Summary
- extract custom stat list logic to new `stat_list_tab`
- remove those widgets from `progress_tab`
- register the new tab in `edit_settings`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a023009d88321b971181833ec30c1