### PR TITLE
Control breeding debug logs via setting

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -354,7 +354,13 @@ class SettingsEditor(tk.Tk):
                 for k, v in reasons.items():
                     if k != "_debug" and v:
                         self.log_message(f"  ✔ {k}")
-                if "_debug" in reasons:
+                debug_cfg = self.settings.get("debug_mode", False)
+                debug_enabled = (
+                    debug_cfg.get("breeding_logic", False)
+                    if isinstance(debug_cfg, dict)
+                    else bool(debug_cfg)
+                )
+                if debug_enabled and "_debug" in reasons:
                     for k, v in reasons["_debug"].items():
                         self.log_message(f"    debug[{k}]: {v}")
 

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -111,7 +111,13 @@ def test_scan_egg(app):
     for k, v in reasons.items():
         if k != "_debug" and v:
             print(f"  ✔ {k}")
-    if "_debug" in reasons:
+    debug_cfg = app.settings.get("debug_mode", False)
+    debug_enabled = (
+        debug_cfg.get("breeding_logic", False)
+        if isinstance(debug_cfg, dict)
+        else bool(debug_cfg)
+    )
+    if debug_enabled and "_debug" in reasons:
         for k, v in reasons["_debug"].items():
             print(f"    debug[{k}]: {v}")
 


### PR DESCRIPTION
## Summary
- respect per-module debug setting when displaying `_debug` messages
- only show breeding logic debug output when `debug_mode['breeding_logic']` (or global bool) is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b86f0b7b0832185f1c8fb990e53f2