### PR TITLE
Add species search filter

### DIFF
--- a/tabs/help_tab.py
+++ b/tabs/help_tab.py
@@ -4,7 +4,7 @@ from tkinter import ttk
 HELP_TEXT = (
     "1. Use 'Run Calibration' on the Tools tab to set screen positions.\n"
     "2. Configure global options and delays in Global Settings.\n"
-    "3. Define per-species rules on the Species Config tab.\n"
+    "3. Use the search box on the Species Config tab to filter and define per-species rules.\n"
     "4. Press the configured hotkey or click Start to begin scanning.\n"
     "5. Script Control provides manual tests and logs."
 )

--- a/tabs/species_tab.py
+++ b/tabs/species_tab.py
@@ -16,6 +16,15 @@ ALL_STATS = ["health", "stamina", "weight", "melee", "oxygen", "food"]
 
 def build_species_tab(app):
     row = 0
+    ttk.Label(app.tab_species, text="Search:", font=FONT).grid(
+        row=row, column=0, sticky="w", padx=5, pady=2
+    )
+    app.search_var = tk.StringVar()
+    search_entry = ttk.Entry(app.tab_species, textvariable=app.search_var, width=30)
+    search_entry.grid(row=row, column=1, sticky="w", padx=5, pady=2)
+    add_tooltip(search_entry, "Filter the species list")
+    row += 1
+
     ttk.Label(app.tab_species, text="Select Species:", font=FONT).grid(
         row=row, column=0, sticky="w", padx=5, pady=2
     )
@@ -34,7 +43,19 @@ def build_species_tab(app):
         width=30,
     )
     app.species_dropdown.grid(row=row, column=1, sticky="w", padx=5, pady=2)
-    add_tooltip(app.species_dropdown, "Select the species whose rules you want to edit")
+    add_tooltip(app.species_dropdown, "Select the species whose rules you want to edit. Use search to filter")
+
+    def update_species_dropdown(_=None):
+        query = app.search_var.get().lower()
+        if query:
+            values = [s for s in app.species_list if query in s.lower()]
+        else:
+            values = list(app.species_list)
+        app.species_dropdown["values"] = values
+
+    app.update_species_dropdown = update_species_dropdown
+    search_entry.bind("<KeyRelease>", update_species_dropdown)
+    update_species_dropdown()
     row += 1
 
     # ---- Sub-tabs for rules vs automation ----

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -8,10 +8,13 @@ def refresh_species_dropdown(app):
     if hasattr(app, "settings"):
         app.progress = load_progress(app.settings.get("current_wipe", "default"))
     species = sorted(app.progress.keys())
-    if hasattr(app, "species_dropdown"):
-        app.species_dropdown["values"] = species
+    app.species_list = species
     if hasattr(app, "progress_dropdown"):
         app.progress_dropdown["values"] = species
+    if hasattr(app, "update_species_dropdown"):
+        app.update_species_dropdown()
+    elif hasattr(app, "species_dropdown"):
+        app.species_dropdown["values"] = species
 
 
 def add_tooltip(widget, text: str) -> None:


### PR DESCRIPTION
## Summary
- add a search field to filter the species dropdown
- expose `update_species_dropdown` for helper refresh
- update help text to mention the new search box

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dba022bbc8321be45cb5359d33442