### PR TITLE
Add flash status indicator for settings saves

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -211,8 +211,16 @@ class SettingsEditor(tk.Tk):
         if hasattr(self, "status_lbl"):
             self.status_lbl["text"] = msg
         if hasattr(self, "status_icon"):
-            colors = {"Running": "green", "Paused": "orange", "Stopped": "red"}
+            colors = {"Running": "green", "Paused": "orange", "Stopped": "red", "Saved": "blue"}
             self.status_icon.config(fg=colors.get(msg, "gray"))
+
+    def flash_status(self, msg: str, duration: int = 2) -> None:
+        """Temporarily show a status message then revert to Idle."""
+        self.update_status(msg)
+        try:
+            self.after(int(duration * 1000), lambda: self.update_status("Idle"))
+        except Exception:
+            pass
 
     def update_hotkeys(self, initial: bool = False):
         """Refresh global hotkeys based on current settings."""

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -1,6 +1,5 @@
 import tkinter as tk
 from tkinter import ttk
-from utils.dialogs import show_info
 from progress_tracker import ensure_wipe_dir, load_progress
 import os
 
@@ -120,9 +119,10 @@ def build_global_tab(app):
             progress_tracker.log = logger.get_logger("progress_tracker")
         except Exception:
             pass
-        show_info("Saved", "Global settings saved.")
         if hasattr(app, "update_hotkeys"):
             app.update_hotkeys()
+        if hasattr(app, "flash_status"):
+            app.flash_status("Saved")
 
     ttk.Button(app.tab_global, text="Save Settings", command=save_all).grid(
         row=row, column=0, columnspan=3, pady=10

--- a/tabs/species_tab.py
+++ b/tabs/species_tab.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 from tkinter import simpledialog
-from utils.dialogs import show_error, show_warning, show_info
+from utils.dialogs import show_error, show_warning
 
 from utils.helpers import refresh_species_dropdown, add_tooltip
 
@@ -245,7 +245,8 @@ def save_species_config(app):
     }
     with open("rules.json", "w", encoding="utf-8") as f:
         json.dump(app.rules, f, indent=2)
-    show_info("Saved", f"Settings for {s} updated.")
+    if hasattr(app, "flash_status"):
+        app.flash_status("Saved")
 
 def delete_species(app):
     s = app.selected_species.get()


### PR DESCRIPTION
## Summary
- add `flash_status` helper to `SettingsEditor`
- color-code saved status in `update_status`
- invoke status flash when saving global and species settings
- drop blocking info popups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dba01521883218d5e1561db2d227c