### PR TITLE
Add hotkey recording feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ pytest
 - **`setup_positions.py`** – Interactive helper to record screen coordinates and regions of interest.
 - **`dump_structure.py`** – Writes a text representation of the repository tree for debugging.
 
+The Global Settings tab also provides a **Record Hotkey** button next to the scan hotkey field to capture a key press automatically.
+
 Other modules implement breeding logic and progress tracking used by these scripts.
 
 ## Discord Bot

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import ttk
 from utils.dialogs import show_info
+import keyboard
 from progress_tracker import ensure_wipe_dir, load_progress
 import os
 
@@ -43,6 +44,23 @@ def build_global_tab(app):
     entry = ttk.Entry(app.tab_global, textvariable=app.hotkey_var, width=10)
     entry.grid(row=row, column=1, sticky="w", padx=5, pady=2)
     add_tooltip(entry, "Keyboard key that triggers the live scan loop")
+
+    def record_hotkey():
+        win = tk.Toplevel(app)
+        win.title("Record Hotkey")
+        ttk.Label(win, text="Press a key...", padding=20).pack()
+        win.attributes("-topmost", True)
+        win.update()
+        key = keyboard.read_key()
+        win.destroy()
+        app.hotkey_var.set(key)
+        app.settings["hotkey_scan"] = key
+        if hasattr(app, "update_hotkeys"):
+            app.update_hotkeys()
+
+    btn_rec = ttk.Button(app.tab_global, text="Record Hotkey", command=record_hotkey)
+    btn_rec.grid(row=row, column=2, sticky="w", padx=5, pady=2)
+    add_tooltip(btn_rec, "Click then press a key to set the scan hotkey")
     row += 1
 
     for delay_key in ["popup_delay", "action_delay", "scan_loop_delay"]:

--- a/tabs/help_tab.py
+++ b/tabs/help_tab.py
@@ -3,7 +3,7 @@ from tkinter import ttk
 
 HELP_TEXT = (
     "1. Use 'Run Calibration' on the Tools tab to set screen positions.\n"
-    "2. Configure global options and delays in Global Settings.\n"
+    "2. Configure global options and delays in Global Settings. Use 'Record Hotkey' to capture the scan key.\n"
     "3. Define per-species rules on the Species Config tab.\n"
     "4. Press the configured hotkey or click Start to begin scanning.\n"
     "5. Script Control provides manual tests and logs."

--- a/utils/calibration.py
+++ b/utils/calibration.py
@@ -32,6 +32,15 @@ def wait_and_record_gui(prompt: str, root: tk.Tk | None = None):
     return x, y
 
 
+def record_hotkey_gui(prompt: str, root: tk.Tk | None = None) -> str:
+    """Display ``prompt`` and return the key pressed."""
+    win = _popup(prompt, root)
+    key = keyboard.read_key()
+    win.destroy()
+    time.sleep(0.2)
+    return key
+
+
 def draw_roi(prompt: str, img):
     """Display ``img`` and let the user draw a rectangle."""
     cv2.namedWindow(prompt, cv2.WINDOW_NORMAL)
@@ -83,7 +92,10 @@ def run_calibration(root: tk.Tk | None = None) -> dict:
         r["y"] += py_
         stat_rois[stat] = r
 
-    hk = simpledialog.askstring("Hotkey", "Enter scan hotkey:", parent=root) or "F8"
+    if messagebox.askyesno("Hotkey", "Record scan hotkey now?", parent=root):
+        hk = record_hotkey_gui("Press desired hotkey", root)
+    else:
+        hk = simpledialog.askstring("Hotkey", "Enter scan hotkey:", parent=root) or "F8"
     pd = simpledialog.askstring("Popup Delay", "Popup delay sec:", parent=root)
     popup_delay = float(pd) if pd else 0.25
     ad = simpledialog.askstring("Action Delay", "Action delay sec:", parent=root)


### PR DESCRIPTION
## Summary
- allow recording hotkey from Global Settings
- optionally record the scan hotkey during calibration
- document the button in README and help text

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dba0084dc83219376905831629b83