### PR TITLE
Integrate top stat updates into stud logic

### DIFF
--- a/edit_settings.py
+++ b/edit_settings.py
@@ -15,7 +15,7 @@ from scanner import scan_slot
 from breeding_logic import should_keep_egg
 from progress_tracker import (
     load_progress, save_progress,
-    update_top_stats, update_mutation_thresholds,
+    update_mutation_thresholds,
     update_stud, update_mutation_stud,
     increment_female_count, adjust_rules_for_females,
     normalize_species_name
@@ -299,10 +299,7 @@ class SettingsEditor(tk.Tk):
                     with open(RULES_FILE, "w", encoding="utf-8") as f:
                         json.dump(self.rules, f, indent=2)
 
-                # Step 1: update top‐stats
-                updated_stats = update_top_stats(egg, stats, progress, wipe)
-
-                # Step 2: decide keep/destroy
+                # Step 1: decide keep/destroy
                 decision, reasons = should_keep_egg(
                     {"egg": egg, "sex": sex, "stats": stats},
                     config,
@@ -317,7 +314,7 @@ class SettingsEditor(tk.Tk):
                             json.dump(self.rules, f, indent=2)
                         self.log_message(f"⚙ Rules updated for {normalized} (females={count})")
 
-                # Step 3: update thresholds only if mutations rule passed
+                # Step 2: update thresholds only if mutations rule passed
                 if reasons.get("mutations"):
                     updated_thresholds = update_mutation_thresholds(
                         egg, stats, config, progress, sex, wipe
@@ -327,7 +324,7 @@ class SettingsEditor(tk.Tk):
 
                 # and only then update stud logic
                 updated_stud = (
-                    update_stud(egg, stats, config, progress)
+                    update_stud(egg, stats, config, progress, wipe)
                     if sex == "male"
                     else False
                 )
@@ -344,12 +341,11 @@ class SettingsEditor(tk.Tk):
                 if updated_stud:
                     self._summary["studs"].append((normalized, stats))
 
-                # Step 4: save progress & UI feedback
+                # Step 3: save progress & UI feedback
                 scan.update({
                     "egg": egg,
                     "sex": sex,
                     "stats": stats,
-                    "updated_stats": updated_stats,
                     "updated_thresholds": updated_thresholds,
                     "updated_stud": updated_stud,
                     "updated_mutation_stud": updated_mstud

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -13,7 +13,7 @@ __test__ = False
 from breeding_logic import should_keep_egg
 from progress_tracker import (
     load_progress, save_progress,
-    update_top_stats, update_mutation_thresholds,
+    update_mutation_thresholds,
     update_stud, update_mutation_stud,
     normalize_species_name
 )
@@ -88,19 +88,17 @@ def test_scan_egg(app):
     wipe = app.settings.get("current_wipe", "default")
     progress = load_progress(wipe)
 
-    updated_stats = update_top_stats(egg, stats, progress, wipe)
     updated_thresholds = update_mutation_thresholds(egg, stats, config, progress, sex, wipe)
     updated_stud = False
     updated_mutation_stud = False
     if sex == "male":
-        updated_stud = update_stud(egg, stats, config, progress)
+        updated_stud = update_stud(egg, stats, config, progress, wipe)
         updated_mutation_stud = update_mutation_stud(egg, stats, config, progress)
 
     scan.update({
         "egg": egg,
         "sex": sex,
         "stats": stats,
-        "updated_stats": updated_stats,
         "updated_thresholds": updated_thresholds,
         "updated_stud": updated_stud,
         "updated_mutation_stud": updated_mutation_stud,


### PR DESCRIPTION
## Summary
- move top stat tracking inside `update_stud` so new studs overwrite and record top stats
- drop separate `update_top_stats` scans; use `update_stud` to refresh stats
- adapt tests and scanning helpers for new stud-driven top stat updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d7b29dc708321b1b881ef4aa40930