### PR TITLE
feat: improve top stat females rule

### DIFF
--- a/breeding_logic.py
+++ b/breeding_logic.py
@@ -140,25 +140,31 @@ def should_keep_egg(scan, rules, progress):
                         result["_debug"]["stat_merge"] = f"{stat} base {base}>{stud.get(stat, 0)}"
                         break
 
-    # ─── Top Stat Females ────────────────────────────────────────
+    # ─── Top Stat Females (equal or higher than current stud) ───
     if "top_stat_females" in enabled and sex == "female":
         log.debug(f"RAW STATS passed into logic: {stats}")
-        log.debug("Evaluating top_stat_females rule")
-        top = progress.get(species, {}).get("top_stats", {})
-        required = rules.get("top_stat_females_stats", [])
+        log.debug("Evaluating top_stat_females rule against stud stats")
+        stud = progress.get(species, {}).get("stud", {})
+        tracked = rules.get("top_stat_females_stats", [])
         mismatched = []
-        match = True
-        for stat in required:
-            top_val = top.get(stat, -999)
+        has_tracked = False
+        for stat in tracked:
+            stud_val = stud.get(stat, 0)
             base_val = stats.get(stat, {}).get("base", 0)
-            if base_val != top_val:
-                match = False
-                mismatched.append(f"{stat}={base_val}≠{top_val}")
-        if match:
+            if base_val < stud_val:
+                mismatched.append(f"{stat}={base_val}<{stud_val}")
+            else:
+                has_tracked = True
+        if has_tracked and not mismatched:
             result["top_stat_females"] = True
-            result["_debug"]["top_stat_females"] = "all matched"
+            result["_debug"]["top_stat_females"] = ">= current stud"
         else:
-            result["_debug"]["top_stat_females"] = f"mismatched: {', '.join(mismatched)}"
+            reason = (
+                f"mismatched: {', '.join(mismatched)}"
+                if mismatched
+                else "no tracked stats"
+            )
+            result["_debug"]["top_stat_females"] = reason
 
     # ─── War Tames ───────────────────────────────────────────────
     if "war" in enabled:

--- a/tests/test_breeding_logic.py
+++ b/tests/test_breeding_logic.py
@@ -91,7 +91,23 @@ class ShouldKeepEggTests(TestCase):
             "stats": {"health": {"base": 10}},
         }
         rules = {"modes": ["top_stat_females"], "top_stat_females_stats": ["health"]}
-        progress = {"TestDino": {"top_stats": {"health": 10}}}
+        progress = {"TestDino": {"stud": {"health": 10}}}
+        with patch("breeding_logic.normalize_species_name", return_value="TestDino"):
+            decision, res = breeding_logic.should_keep_egg(scan, rules, progress)
+        self.assertEqual(decision, "keep")
+        self.assertTrue(res["top_stat_females"])
+        log_msg = self.keep_stream.getvalue()
+        self.assertIn("KEPT", log_msg)
+        self.assertIn("top_stat_females:", log_msg)
+
+    def test_top_stat_females_improve_stat(self):
+        scan = {
+            "egg": "CS Test Female",
+            "sex": "female",
+            "stats": {"health": {"base": 12}},
+        }
+        rules = {"modes": ["top_stat_females"], "top_stat_females_stats": ["health"]}
+        progress = {"TestDino": {"stud": {"health": 10}}}
         with patch("breeding_logic.normalize_species_name", return_value="TestDino"):
             decision, res = breeding_logic.should_keep_egg(scan, rules, progress)
         self.assertEqual(decision, "keep")


### PR DESCRIPTION
## Summary
- evaluate top stat females against current stud instead of top stats
- keep females whose tracked stats are all at least as high as stud's
- add test covering female that improves a stud stat

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7bc9d7088321978229e3405a6c14