### PR TITLE
Revise automated mode thresholds

### DIFF
--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -240,17 +240,14 @@ def apply_automated_modes(female_count, modes):
     if "automated" not in modes:
         return modes
 
-    if female_count < 15:
+    if female_count < 5:
         modes.update({"mutations", "stat_merge", "all_females"})
         modes.discard("top_stat_females")
     elif female_count < 96:
         modes.update({"mutations", "stat_merge", "top_stat_females"})
         modes.discard("all_females")
     else:
-        modes.update({"mutations", "stat_merge"})
-        modes.discard("all_females")
-        modes.discard("top_stat_females")
-        modes.discard("automated")
+        modes = {"war"} if "war" in modes else set()
 
     return modes
 

--- a/tests/test_breeding_logic.py
+++ b/tests/test_breeding_logic.py
@@ -135,10 +135,10 @@ class ShouldKeepEggTests(TestCase):
         self.assertEqual(decision, "rescan")
         self.assertEqual(res["_debug"]["final"], "rescan")
 
-    def test_automated_all_females_under_15(self):
+    def test_automated_all_females_under_threshold(self):
         scan = {"egg": "CS Test Female", "sex": "female", "stats": {}}
         rules = {"modes": ["automated"]}
-        progress = {"TestDino": {"female_count": 10}}
+        progress = {"TestDino": {"female_count": 4}}
         with patch("breeding_logic.normalize_species_name", return_value="TestDino"):
             decision, res = breeding_logic.should_keep_egg(scan, rules, progress)
         self.assertEqual(decision, "keep")
@@ -168,3 +168,12 @@ class ShouldKeepEggTests(TestCase):
         with patch("breeding_logic.normalize_species_name", return_value="TestDino"):
             decision, res = breeding_logic.should_keep_egg(scan, rules, progress)
         self.assertEqual(decision, "destroy")
+
+    def test_automated_high_count_keeps_war(self):
+        scan = {"egg": "CS Test Male", "sex": "male", "stats": {"melee": {"base": 5}}}
+        rules = {"modes": ["automated", "war"], "war_stats": ["melee"]}
+        progress = {"TestDino": {"female_count": 120, "top_stats": {"melee": 5}}}
+        with patch("breeding_logic.normalize_species_name", return_value="TestDino"):
+            decision, res = breeding_logic.should_keep_egg(scan, rules, progress)
+        self.assertEqual(decision, "keep")
+        self.assertTrue(res["war"])

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -69,7 +69,16 @@ def test_adjust_rules_for_females_high_count():
     with patch('progress_tracker.log'):
         changed = progress_tracker.adjust_rules_for_females('Rex', progress, rules)
     assert changed is True
-    assert set(rules['Rex']['modes']) == {'mutations', 'stat_merge'}
+    assert set(rules['Rex']['modes']) == set()
+
+
+def test_adjust_rules_for_females_high_count_war():
+    progress = {'Rex': {'female_count': 150}}
+    rules = {'Rex': {'modes': ['automated', 'war']}}
+    with patch('progress_tracker.log'):
+        changed = progress_tracker.adjust_rules_for_females('Rex', progress, rules)
+    assert changed is True
+    assert set(rules['Rex']['modes']) == {'war'}
 
 
 def test_update_mutation_stud_updates_value():
@@ -106,7 +115,7 @@ def test_update_stud_equal_match_better_base():
 
 
 def test_apply_automated_modes_low_count():
-    modes = progress_tracker.apply_automated_modes(10, {'automated'})
+    modes = progress_tracker.apply_automated_modes(4, {'automated'})
     assert modes == {'automated', 'mutations', 'stat_merge', 'all_females'}
 
 
@@ -117,7 +126,12 @@ def test_apply_automated_modes_mid_count():
 
 def test_apply_automated_modes_high_count():
     modes = progress_tracker.apply_automated_modes(120, {'all_females', 'top_stat_females', 'automated'})
-    assert modes == {'mutations', 'stat_merge'}
+    assert modes == set()
+
+
+def test_apply_automated_modes_high_count_war():
+    modes = progress_tracker.apply_automated_modes(120, {'automated', 'war'})
+    assert modes == {'war'}
 
 
 def test_record_history_custom_wipe(tmp_path):


### PR DESCRIPTION
## Summary
- Adjust automated mode thresholds to <5, 5-95, and >=96 with special war handling
- Update automated mode logic and callers for new thresholds
- Expand tests covering new threshold ranges and war mode preservation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d7bf28da88321a2fa68cdf05bfba6