### PR TITLE
Add monitored scan mode with user prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ pytest
 
 Other modules implement breeding logic and progress tracking used by these scripts.
 
+## Monitored Scan
+
+The `settings.json` file includes a `monitored_scan` option. When enabled, the live
+scan loop pauses upon encountering a species not listed in `rules.json` and asks
+which modes and stats to track. The chosen configuration is saved and scanning
+resumes. If disabled, new species are added automatically using the default
+species template without interrupting the loop. The setting can be toggled from
+the Global tab of the settings editor.
+
 ## Discord Bot
 
 `discord_bot.py` implements a small Discord bot that can control the game and report breeding progress. Set your bot token in `settings.json` under the `bot_token` key or provide it via the `DISCORD_BOT_TOKEN` environment variable. Start the bot with:

--- a/edit_settings.py
+++ b/edit_settings.py
@@ -24,7 +24,7 @@ from progress_tracker import (
 from tabs.global_tab import build_global_tab
 from tabs.species_tab import build_species_tab
 from tabs.tools_tab import build_tools_tab
-from tabs.script_control_tab import build_test_tab
+from tabs.script_control_tab import build_test_tab, prompt_new_species
 from tabs.progress_tab import build_stats_tab
 from utils.config_validator import validate_configs
 from utils.helpers import refresh_species_dropdown
@@ -280,24 +280,31 @@ class SettingsEditor(tk.Tk):
                 sex = "female" if "female" in egg.lower() else "male"
                 normalized = normalize_species_name(egg)
 
-                config = self.rules.get(
-                    normalized, self.settings.get("default_species_template", {})
-                )
+                config = self.rules.get(normalized)
                 wipe = self.settings.get("current_wipe", "default")
                 progress = load_progress(wipe)
                 new_species = False
-                if normalized not in progress:
+                if config is None:
                     new_species = True
-                    # initialize rules entry from the default template and
-                    # ensure automated mode is always enabled
-                    template = deepcopy(self.settings.get("default_species_template", {}))
-                    modes = set(template.get("modes", []))
+                    if self.settings.get("monitored_scan", True):
+                        self.log_message(f"⏸ New species detected: {normalized}")
+                        self.scanning_paused = True
+                        self.update_status("Paused")
+                        cfg = prompt_new_species(self, normalized)
+                        self.scanning_paused = False
+                        self.update_status("Running")
+                        if cfg is None:
+                            cfg = deepcopy(self.settings.get("default_species_template", {}))
+                    else:
+                        cfg = deepcopy(self.settings.get("default_species_template", {}))
+                    modes = set(cfg.get("modes", []))
                     modes.add("automated")
-                    template["modes"] = list(modes)
-                    self.rules[normalized] = template
-                    config = self.rules[normalized]
+                    cfg["modes"] = list(modes)
+                    self.rules[normalized] = cfg
+                    config = cfg
                     with open(RULES_FILE, "w", encoding="utf-8") as f:
                         json.dump(self.rules, f, indent=2)
+                    self.log_message(f"✔ Added {normalized} to rules")
 
                 # Step 1: update top‐stats
                 updated_stats = update_top_stats(egg, stats, progress, wipe)

--- a/settings.json
+++ b/settings.json
@@ -16,6 +16,7 @@
   "webhook_url": "",
   "bot_token": "",
   "debug_mode": false,
+  "monitored_scan": true,
   "drop_all_button": [
     495,
     196

--- a/tabs/global_tab.py
+++ b/tabs/global_tab.py
@@ -75,6 +75,12 @@ def build_global_tab(app):
     add_tooltip(cb_auto, "Automatically consume food periodically")
     row += 1
 
+    app.monitored_scan_var = tk.BooleanVar(value=app.settings.get("monitored_scan", True))
+    cb_mon = ttk.Checkbutton(app.tab_global, text="Monitored Scan", variable=app.monitored_scan_var)
+    cb_mon.grid(row=row, column=2, sticky="w", padx=5, pady=2)
+    add_tooltip(cb_mon, "Pause on unknown species to configure rules")
+    row += 1
+
     ttk.Label(app.tab_global, text="Per-Module Debug:", font=FONT).grid(
         row=row, column=0, sticky="w", padx=5, pady=(10, 2)
     )
@@ -101,6 +107,7 @@ def build_global_tab(app):
         app.settings["action_delay"] = app.action_delay_var.get()
         app.settings["scan_loop_delay"] = app.scan_loop_delay_var.get()
         app.settings["auto_eat_enabled"] = app.auto_eat_var.get()
+        app.settings["monitored_scan"] = app.monitored_scan_var.get()
         app.settings["debug_mode"] = {k: v.get() for k, v in app.debug_vars.items()}
         app.settings["current_wipe"] = app.wipe_var.get() or "default"
         ensure_wipe_dir(app.settings["current_wipe"])

--- a/tabs/script_control_tab.py
+++ b/tabs/script_control_tab.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import ttk, scrolledtext
+from tkinter import ttk, scrolledtext, simpledialog
 import time
 from scanner import scan_slot
 from utils.helpers import add_tooltip
@@ -17,6 +17,32 @@ from progress_tracker import (
     update_stud, update_mutation_stud,
     normalize_species_name
 )
+
+
+def prompt_new_species(app, species):
+    """Ask user for modes and stats for a newly discovered species."""
+    default = app.settings.get("default_species_template", {})
+    modes_init = ",".join(default.get("modes", []))
+    stats_init = ",".join(default.get("mutation_stats", []))
+    modes_str = simpledialog.askstring(
+        "New Species", f"Enter modes for {species} (comma separated):", initialvalue=modes_init
+    )
+    if modes_str is None:
+        return None
+    stats_str = simpledialog.askstring(
+        "New Species", f"Stats to track for {species} (comma separated):", initialvalue=stats_init
+    )
+    if stats_str is None:
+        return None
+    stats_list = [s.strip() for s in stats_str.split(',') if s.strip()]
+    config = {
+        "modes": [m.strip() for m in modes_str.split(',') if m.strip()],
+        "mutation_stats": stats_list,
+        "stat_merge_stats": stats_list,
+        "top_stat_females_stats": stats_list,
+        "war_stats": stats_list,
+    }
+    return config
 
 def build_test_tab(app):
     ttk.Label(app.tab_test, text="Main Scripts", font=(FONT[0], FONT[1], "bold")).pack(pady=(10, 2))

--- a/utils/calibration.py
+++ b/utils/calibration.py
@@ -105,6 +105,7 @@ def run_calibration(root: tk.Tk | None = None) -> dict:
         "popup_delay": popup_delay,
         "action_delay": action_delay,
         "hotkey_scan": hk,
+        "monitored_scan": True,
         "debug_mode": debug_mode,
         "drop_all_button": drop_all_button,
         "food_slots": food_slots,

--- a/utils/config_validator.py
+++ b/utils/config_validator.py
@@ -20,6 +20,7 @@ def validate_settings(settings: Dict[str, Any]) -> List[str]:
         "popup_delay": (int, float),
         "action_delay": (int, float),
         "hotkey_scan": str,
+        "monitored_scan": bool,
         "debug_mode": (bool, dict),
         "webhook_url": str,
         "bot_token": str,


### PR DESCRIPTION
## Summary
- add `monitored_scan` setting and UI toggle
- prompt for modes/stats when unknown species is scanned and persist in `rules.json`
- document new monitored scanning workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d7c0d13788321bf0b2d0986209f54