### PR TITLE
Handle missing OCR dependencies

### DIFF
--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -22,3 +22,29 @@ def test_is_invalid_all_zero_stats():
     }
     assert scanner.is_invalid(scan) is False
 
+
+def test_scan_once_no_ocr(monkeypatch):
+    import importlib
+    import types
+
+    monkeypatch.setitem(sys.modules, 'cv2', None)
+    monkeypatch.setitem(sys.modules, 'pytesseract', None)
+    monkeypatch.setitem(
+        sys.modules,
+        'pyautogui',
+        types.SimpleNamespace(onScreen=lambda *a, **k: False)
+    )
+
+    reloaded = importlib.reload(scanner)
+
+    settings = {
+        'slot_x': 0,
+        'slot_y': 0,
+        'species_roi': {'x': 0, 'y': 0, 'w': 0, 'h': 0},
+        'stat_rois': {},
+        'ocr': {'oem': 3, 'psm': 7},
+    }
+
+    assert reloaded.OCR_AVAILABLE is False
+    assert reloaded.scan_once(settings) == 'ocr_unavailable'
+

--- a/utils/calibration.py
+++ b/utils/calibration.py
@@ -3,7 +3,12 @@ import time
 import tkinter as tk
 from tkinter import messagebox, simpledialog
 
-import cv2
+try:
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - calibration not run in tests
+    cv2 = None
+    print("OpenCV (cv2) not available. Calibration features disabled.")
+
 import numpy as np
 import pyautogui
 import keyboard
@@ -34,6 +39,8 @@ def wait_and_record_gui(prompt: str, root: tk.Tk | None = None):
 
 def draw_roi(prompt: str, img):
     """Display ``img`` and let the user draw a rectangle."""
+    if cv2 is None:
+        raise RuntimeError("OpenCV (cv2) is required for ROI drawing")
     cv2.namedWindow(prompt, cv2.WINDOW_NORMAL)
     cv2.setWindowProperty(prompt, cv2.WND_PROP_TOPMOST, 1)
     sw, sh = pyautogui.size()
@@ -46,6 +53,8 @@ def draw_roi(prompt: str, img):
 
 def run_calibration(root: tk.Tk | None = None) -> dict:
     """Interactive calibration with GUI prompts."""
+    if cv2 is None:
+        raise RuntimeError("OpenCV (cv2) is required for calibration")
     messagebox.showinfo(
         "Calibration",
         "Follow the prompts. Move your mouse to the requested location and press F9",


### PR DESCRIPTION
## Summary
- gracefully handle missing `cv2` and `pytesseract` by logging warnings and disabling scanning
- guard calibration utilities against absent OpenCV
- test scanner behavior when OCR libraries are unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7c7634e88321928de8556cb2e342