### PR TITLE
Capture minimal screenshot region

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -105,10 +105,29 @@ def scan_once(settings, debug=False):
     time.sleep(settings.get("popup_delay", 0.0))
     log.debug("Clicked slot at (%d,%d)", x, y)
 
-    full = cv2.cvtColor(np.array(pyautogui.screenshot()), cv2.COLOR_RGB2BGR)
+    # Calculate the bounding rectangle containing the species ROI and all stat ROIs
+    sx, sy, sw, sh = settings["species_roi"].values()
+    bounds = [
+        (sx, sy, sx + sw, sy + sh),
+    ]
+    for roi in settings["stat_rois"].values():
+        x0, y0, w0, h0 = roi.values()
+        bounds.append((x0, y0, x0 + w0, y0 + h0))
+
+    min_x = min(b[0] for b in bounds)
+    min_y = min(b[1] for b in bounds)
+    max_x = max(b[2] for b in bounds)
+    max_y = max(b[3] for b in bounds)
+
+    region = (min_x, min_y, max_x - min_x, max_y - min_y)
+    full = cv2.cvtColor(
+        np.array(pyautogui.screenshot(region=region)), cv2.COLOR_RGB2BGR
+    )
 
     # Species OCR
     sx, sy, sw, sh = settings["species_roi"].values()
+    sx -= min_x
+    sy -= min_y
     crop_sp = full[sy:sy+sh, sx:sx+sw]
     sp_txt = pytesseract.image_to_string(
         cv2.cvtColor(crop_sp, cv2.COLOR_BGR2GRAY),
@@ -125,6 +144,8 @@ def scan_once(settings, debug=False):
     stats = {}
     for stat, roi in settings["stat_rois"].items():
         x0, y0, w0, h0 = roi.values()
+        x0 -= min_x
+        y0 -= min_y
         crop = full[y0:y0+h0, x0:x0+w0]
 
         prim = baseline_up(crop)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,8 +1,28 @@
 import sys
 import types
+import numpy as np
+import os
+
+# Ensure project root on path for importing scanner when tests executed from subdirectory
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 
 # Provide dummy pyautogui so scanner can import without a display
-sys.modules['pyautogui'] = types.SimpleNamespace(onScreen=lambda *a, **k: False)
+def _dummy_screenshot(region=None):
+    w = region[2] if region else 1
+    h = region[3] if region else 1
+    return np.zeros((h, w, 3), dtype=np.uint8)
+
+
+sys.modules['pyautogui'] = types.SimpleNamespace(
+    onScreen=lambda *a, **k: False,
+    screenshot=_dummy_screenshot,
+    moveTo=lambda *a, **k: None,
+    click=lambda *a, **k: None,
+)
+
+# Minimal stub of cv2 to avoid heavy dependencies during import
+sys.modules.setdefault('cv2', types.SimpleNamespace())
 
 import scanner
 


### PR DESCRIPTION
## Summary
- capture screenshot of minimal bounding rectangle around species and stat ROIs
- adjust ROI coordinates relative to captured region
- stub pyautogui and cv2 in scanner tests to accommodate new screenshot behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7d29e8048321961cab416d2a5709