### PR TITLE
Allow overriding Tesseract path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Execute all unit tests with:
 pytest
 ```
 
+## OCR Configuration
+
+The scanner uses [PyTesseract](https://pypi.org/project/pytesseract/) for optical character
+recognition. If the `tesseract` executable is not on your `PATH`, set the
+`ocr.tesseract_cmd` option in `settings.json` to point to it. `scanner.scan_once`
+copies this value to `pytesseract.pytesseract.tesseract_cmd` before performing
+any OCR calls.
+
 ## Main Scripts
 
 - **`edit_settings.py`** – Tkinter GUI for editing configuration and viewing a summary of tracked stats.

--- a/scanner.py
+++ b/scanner.py
@@ -95,6 +95,12 @@ def ocr_number(img, oem, psm):
 
 def scan_once(settings, debug=False):
     log.debug("scan_once: start")
+    tess_cmd = (
+        settings.get("ocr", {}).get("tesseract_cmd")
+        or settings.get("tesseract_cmd")
+    )
+    if tess_cmd:
+        pytesseract.pytesseract.tesseract_cmd = tess_cmd
     x, y = settings["slot_x"], settings["slot_y"]
     if not pyautogui.onScreen(x, y):
         log.warning("Slot off-screen, skipping scan.")

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -22,3 +22,12 @@ def test_is_invalid_all_zero_stats():
     }
     assert scanner.is_invalid(scan) is False
 
+
+def test_scan_once_sets_tesseract_cmd(monkeypatch):
+    dummy_pt = types.SimpleNamespace(pytesseract=types.SimpleNamespace())
+    monkeypatch.setattr(scanner, "pytesseract", dummy_pt)
+    monkeypatch.setattr(scanner.pyautogui, "onScreen", lambda *a, **k: False)
+    settings = {"slot_x": 0, "slot_y": 0, "ocr": {"tesseract_cmd": "custom"}}
+    scanner.scan_once(settings)
+    assert dummy_pt.pytesseract.tesseract_cmd == "custom"
+


### PR DESCRIPTION
## Summary
- allow scanner to override pytesseract binary path via settings
- document `ocr.tesseract_cmd` configuration option
- test the new tesseract command assignment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7d389efc8321b8dc5da5a27fe03e